### PR TITLE
change from optparse to argparse

### DIFF
--- a/b3/run.py
+++ b/b3/run.py
@@ -41,7 +41,11 @@ import traceback
 from b3.functions import main_is_frozen
 from b3.setup import Setup
 from b3.setup import Update
-from optparse import OptionParser
+
+try: import argparse
+except ImportError:
+    import b3.lib.argparse as argparse
+
 import pkg_handler
 
 
@@ -152,24 +156,24 @@ def run_update(config=None):
     Update(config)
 
 def main():
-    parser = OptionParser(version=b3.getB3versionString())
-    parser.add_option('-c', '--config', dest='config', default=None,
+    parser = argparse.ArgumentParser(version=b3.getB3versionString())
+    parser.add_argument('-c', '--config', dest='config', default=None,
                       help='B3 config file. Example: -c b3.xml')
-    parser.add_option('-r', '--restart',
+    parser.add_argument('-r', '--restart',
                       action='store_true', dest='restart', default=False,
                       help='Auto-restart B3 on crash')
-    parser.add_option('-s', '--setup',
+    parser.add_argument('-s', '--setup',
                       action='store_true', dest='setup', default=False,
                       help='Setup main b3.xml config file')
-    parser.add_option('-u', '--update',
+    parser.add_argument('-u', '--update',
                       action='store_true', dest='update', default=False,
                       help='Update B3 database to latest version')
-    parser.add_option('-n', '--nosetup',
+    parser.add_argument('-n', '--nosetup',
                       action="store_true", dest='nosetup', default=False,
                       help='Do not enter setup mode when config is missing')
 
 
-    (options, args) = parser.parse_args()
+    (options, args) = parser.parse_known_args()
 
     if not options.config and len(args) == 1:
         options.config = args[0]


### PR DESCRIPTION
optparse replaced by argparse.
argparse is from python-2.7 in the standard library. For python 2.6, the bundled version of B3 is used.

Or http://www.python.org/dev/peps/pep-0389/#why-aren-t-getopt-and-optparse-enough
