### PR TITLE
add spell check like "Did you mean ?" for commands

### DIFF
--- a/b3/functions.py
+++ b/b3/functions.py
@@ -41,6 +41,7 @@ import imp
 import string
 import urllib2
 from hashlib import md5
+import collections
 
 
 def getModule(name):
@@ -348,3 +349,43 @@ def getStuffSoundingLike(stuff, expected_stuff):
 
 def hash_password(password):
     return md5(password).hexdigest()
+
+# simplified spell checker from Peter Norvig
+# http://www.norvig.com/spell-correct.html
+def corrent_spell(c_word, wordbook):
+
+    def words(text): return re.findall('[a-z]+', text.lower())
+
+    def train(features):
+        model = collections.defaultdict(lambda: 1)
+        for f in features:
+            model[f] += 1
+        return model
+
+    NWORDS = train(words(wordbook))
+
+    alphabet = 'abcdefghijklmnopqrstuvwxyz'
+
+    def edits1(word):
+        splits     = [(word[:i], word[i:]) for i in range(len(word) + 1)]
+        deletes    = [a + b[1:] for a, b in splits if b]
+        transposes = [a + b[1] + b[0] + b[2:] for a, b in splits if len(b)>1]
+        replaces   = [a + c + b[1:] for a, b in splits for c in alphabet if b]
+        inserts    = [a + c + b     for a, b in splits for c in alphabet]
+        return set(deletes + transposes + replaces + inserts)
+
+    def known_edits2(word):
+        return set(e2 for e1 in edits1(word) for e2 in edits1(e1) if e2 in NWORDS)
+
+    def known(words): return set(w for w in words if w in NWORDS)
+
+    def correct(word):
+        candidates = known([word]) or known(edits1(word)) or known_edits2(word) or [word]
+        return max(candidates, key=NWORDS.get)
+
+    result = correct(c_word)
+    if result == c_word:
+        result = False
+
+    return result
+

--- a/b3/plugins/admin.py
+++ b/b3/plugins/admin.py
@@ -406,8 +406,14 @@ class AdminPlugin(b3.plugin.Plugin):
                         self.warnClient(event.client, 'fakecmd', None, False)
                         return
                 if not self._warn_command_abusers and event.client.maxLevel < self._admins_level:
+                    spellcheck = self.get_cmdSoundingLike(cmd, event.client)
+                    if spellcheck:
+                        cmd += '. Did you mean %s ?' % spellcheck
                     event.client.message(self.getMessage('unknown_command', cmd))
                 elif event.client.maxLevel > self._admins_level:
+                    spellcheck = self.get_cmdSoundingLike(cmd, event.client)
+                    if spellcheck:
+                        cmd += '. Did you mean %s ?' % spellcheck
                     event.client.message(self.getMessage('unknown_command', cmd))
                 return
 
@@ -2168,7 +2174,14 @@ class AdminPlugin(b3.plugin.Plugin):
             self.info("""{0:<10s} {1:<10s}\t"{2}" """.format(keyword, functions.minutesStr(duration), reason))
         self.info("-------------- warn_reasons loaded ----------------")
 
-
+    def get_cmdSoundingLike(self, c_word, client):
+        c_list = []
+        for c, cmd in self._commands.iteritems():
+            if cmd.canUse(client):
+                if cmd.command not in c_list:
+                    c_list.append(cmd.command)
+        result = functions.corrent_spell(c_word, ' '.join(c_list))
+        return result
 
 
 #--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
samples expain it ;)

```
>>> superadmin.says('!pputgroup')
sending msg to God: Unrecognized command pputgroup. Dit you mean putgroup ?
```

```
>>> superadmin.says('!yhel')
sending msg to God: Unrecognized command yhel. Dit you mean help ?
```

The existing soundex and getStuffSoundingLike() implementations yielded poor results. In my tests with the code from Peter Norvig was the result always correct. By the way, an interesting read: http://www.norvig.com/spell-correct.html
