### PR TITLE
use ElementTree

### DIFF
--- a/b3/config.py
+++ b/b3/config.py
@@ -35,24 +35,21 @@
 # 11/04/2012 - 1.4 - Courgette
 # CfgConfigParser now implements methods getDuration, getboolean, getpath, loadFromString
 #
-__author__  = 'ThorN'
+__author__ = 'ThorN'
 __version__ = '1.4'
 
 import sys, time
 import b3
 from xml.parsers.expat import ExpatError
 
+# Import ElementTree
 try:
-    from b3.lib.elementtree import ElementTree
-except ImportError, err:
+    from xml.etree import cElementTree as ElementTree
+except ImportError:
     try:
         from xml.etree import ElementTree
-    except ImportError, err:
-        sys.stderr.write("""FATAL ERROR : Cannot load elementtree
-      Check that you have installed ElementTree.
-      On Linux Debian : apt-get install python-elementtree
-      """)
-        sys.exit(1)
+    except ImportError:
+        from b3.lib.elementtree import ElementTree
 
 import ConfigParser
 import os
@@ -135,7 +132,7 @@ class XmlConfigParser(B3ConfigParserMixin):
             self._settings[section] = {}
 
             for setting in settings.findall("./set"):
-                name  = setting.get('name')
+                name = setting.get('name')
                 value = setting.text
 
                 self._settings[section][name] = value
@@ -201,7 +198,7 @@ class XmlConfigParser(B3ConfigParserMixin):
         self.readfp(f)
         f.close()
 
-        self.fileName  = fileName
+        self.fileName = fileName
         self.fileMtime = os.path.getmtime(self.fileName)
 
         return True
@@ -210,10 +207,10 @@ class XmlConfigParser(B3ConfigParserMixin):
         """\
         Read the xml config from a string
         """
-        
-        self.fileName  = None
+
+        self.fileName = None
         self.fileMtime = time.time()
-        
+
         try:
             self._xml = ElementTree.XML(xmlstring)
         except ExpatError, e:
@@ -229,7 +226,7 @@ class XmlConfigParser(B3ConfigParserMixin):
     def set(self, section, option, value):
         # not implemented
         pass
-        
+
 
 class CfgConfigParser(B3ConfigParserMixin, ConfigParser.ConfigParser):
     """\
@@ -251,7 +248,7 @@ class CfgConfigParser(B3ConfigParserMixin, ConfigParser.ConfigParser):
         self.readfp(f)
         f.close()
 
-        self.fileName  = fileName
+        self.fileName = fileName
         self.fileMtime = os.path.getmtime(self.fileName)
 
         return True
@@ -259,10 +256,11 @@ class CfgConfigParser(B3ConfigParserMixin, ConfigParser.ConfigParser):
     def loadFromString(self, cfg_string):
         """ Read the cfg config from a string """
         import StringIO
+
         fp = StringIO.StringIO(cfg_string)
         self.readfp(fp)
         fp.close()
-        self.fileName  = None
+        self.fileName = None
         self.fileMtime = time.time()
         return True
 
@@ -272,7 +270,6 @@ class CfgConfigParser(B3ConfigParserMixin, ConfigParser.ConfigParser):
         f.close()
 
         return True
-
 
 
 def load(fileName):
@@ -296,6 +293,7 @@ def load(fileName):
 class ConfigFileNotFound(Exception):
     def __init__(self, value):
         Exception.__init__(self, value)
+
     def __str__(self):
         return repr(self.value)
 
@@ -303,5 +301,6 @@ class ConfigFileNotFound(Exception):
 class ConfigFileNotValid(Exception):
     def __init__(self, value):
         Exception.__init__(self, value)
+
     def __str__(self):
         return repr(self.value)

--- a/b3/parser.py
+++ b/b3/parser.py
@@ -178,7 +178,16 @@ import b3.timezones
 from ConfigParser import NoOptionError
 from b3.functions import getModule, vars2printf
 from b3.decorators import memoize
-from b3.lib.elementtree import ElementTree
+
+# Import ElementTree
+try:
+    from xml.etree import cElementTree as ElementTree
+except ImportError:
+    try:
+        from xml.etree import ElementTree
+    except ImportError:
+        from b3.lib.elementtree import ElementTree
+
 
 class Parser(object):
     _lineFormat = re.compile('^([a-z ]+): (.*?)', re.IGNORECASE)

--- a/b3/setup.py
+++ b/b3/setup.py
@@ -80,7 +80,16 @@ import glob
 import pkg_handler
 import functions
 import tempfile
-from lib.elementtree.ElementTree import ElementTree
+
+# Import ElementTree
+try:
+    from xml.etree import cElementTree as ElementTree
+except ImportError:
+    try:
+        from xml.etree import ElementTree
+    except ImportError:
+        from b3.lib.elementtree import ElementTree
+
 from lib.elementtree.SimpleXMLWriter import XMLWriter
 from distutils import version
 from urlparse import urlsplit

--- a/tests/plugins/test_admin_functional.py
+++ b/tests/plugins/test_admin_functional.py
@@ -504,7 +504,14 @@ class Test_config(Admin_functional_test):
     def test_no_generic_or_default_warn_readon(self):
 
         # load the default plugin_admin.xml file after having remove the 'generic' setting from section 'warn_reasons'
-        from b3.lib.elementtree import ElementTree as ET
+        try:
+            from xml.etree import cElementTree as ET
+        except ImportError:
+            try:
+                from xml.etree import ElementTree as ET
+            except ImportError:
+                from b3.lib.elementtree import ElementTree as ET
+
         root = ET.parse(ADMIN_CONFIG_FILE).getroot()
         warn_reasons_nodes = [x for x in root.findall('settings') if x.get('name') == 'warn_reasons' ][0]
         if len(warn_reasons_nodes):


### PR DESCRIPTION
## cElementTree

The advantages are obvious. (massive speed improvements and smaller memory footprint)
cElementTree is included in the most linux distribution and the python 4 windows distribution have it too.
## ElementTree

shipped with python standard library since version 2.5.
## SimpleXMLWriter

Is not really needed. If some changes are made​​, this dependence can be removed.

Why remove lib/elementtree from B3?
- Python provides everything needed
- The code's ancient
- The maintenance will be obsolete
