### PR TITLE
skip update check if configured

### DIFF
--- a/b3/__init__.py
+++ b/b3/__init__.py
@@ -140,14 +140,16 @@ def start(configFile, nosetup=False):
         update_channel = conf.get('update', 'channel')
     except (ConfigParser.NoSectionError, ConfigParser.NoOptionError):
         pass
-    _update = checkUpdate(__version__, channel=update_channel, singleLine=False, showErrormsg=True)
-    if _update:
-        print _update
-        time.sleep(5)
+    if update_channel == 'skip':
+        print "Skipping check if a update is available."
     else:
-        print "...no update available."
-        time.sleep(1)
-
+        _update = checkUpdate(__version__, channel=update_channel, singleLine=False, showErrormsg=True)
+        if _update:
+            print _update
+            time.sleep(5)
+        else:
+            print "...no update available."
+            time.sleep(1)
 
     try:
         parserType = conf.get('b3', 'parser')

--- a/b3/conf/b3.distribution.xml
+++ b/b3/conf/b3.distribution.xml
@@ -79,7 +79,9 @@ homefront/ro2/csgo/ravaged/arma2
                 stable : will only show stable releases of B3
                 beta : will also check if a beta release is available
                 dev : will also check if a development release is available
-            If you don't know what channel to use, use 'stable'
+            If you don't know what channel to use, use 'stable'.
+
+                skip : will skip the update check
         -->
         <set name="channel">stable</set>
     </settings>


### PR DESCRIPTION
Allows the update checking to skip if the configuration of the channel is set to "skip".
Useful for developers.
