### PR TITLE
improved player matching output

### DIFF
--- a/b3/plugins/admin.py
+++ b/b3/plugins/admin.py
@@ -577,7 +577,10 @@ class AdminPlugin(b3.plugin.Plugin):
             if len(matches) > 1:
                 names = []
                 for _p in matches:
-                    names.append('^7%s [^2%s^7]' % (_p.name, _p.cid))
+                    if _p.name == _p.cid:
+                        names.append('^7%s' % (_p.name))
+                    else:
+                        names.append('^7%s [^2%s^7]' % (_p.name, _p.cid))
 
                 if client:
                     client.message(self.getMessage('players_matched', client_id, ', '.join(names)))


### PR DESCRIPTION
example, on some parsers are client.name == client.cid ...that result in  "Players matching on ozon [ozon]"
this little change cleans up the output
