### PR TITLE
[CSGO] fix regression from v1.5 that made B3 never disconnect leaving pl...

### DIFF
--- a/tests/plugins/test_admin_functional.py
+++ b/tests/plugins/test_admin_functional.py
@@ -1548,3 +1548,21 @@ class Cmd_kick(Admin_functional_test):
         self.joe.says('!kick 4')
         # THEN
         self.assertListEqual([call('4', '', self.joe)], self.kick_mock.mock_calls)
+
+    def test_existing_player_by_name_containing_spaces(self):
+        # GIVEN
+        self.mike.connects('1')
+        self.mike.name = "F 0 0"
+        # WHEN
+        self.joe.says('!kick f00 the reason')
+        # THEN
+        self.assertListEqual([call(self.mike, 'the reason', self.joe, False)], self.kick_mock.mock_calls)
+
+    def test_existing_player_by_name_containing_spaces_2(self):
+        # GIVEN
+        self.mike.connects('1')
+        self.mike.name = "F 0 0"
+        # WHEN
+        self.joe.says("!kick 'f 0 0' the reason")
+        # THEN
+        self.assertListEqual([call(self.mike, 'the reason', self.joe, False)], self.kick_mock.mock_calls)


### PR DESCRIPTION
...ayers

See http://forum.bigbrotherbot.net/counter-strike-global-offensive/any-way-to-stop-bot-registrations/msg41564/#msg41564

When a player disconnects, two lines are found in the game log : 

```
L 07/19/2013 - 17:18:44: "f00<2008><STEAM_1:0:11111111><TERRORIST>" disconnected (reason "Disconnect by user.")
L 07/19/2013 - 17:18:44: "f00<2008><STEAM_1:0:11111111>" switched from team <TERRORIST> to <Unassigned>
```

when parsing the 2nd line, B3 MUST NOT recreate the client object 
