### PR TITLE
[BF4] handle comrose chat id's as event

### DIFF
--- a/tests/parsers/test_bf4.py
+++ b/tests/parsers/test_bf4.py
@@ -337,6 +337,27 @@ class Test_bf3_events(BF4TestCase):
         self.assertEquals('test squad', event.data)
         self.assertEqual(self.joe, event.client)
 
+    def test_player_onChat_event_squad_comrose(self):
+        self.parser.getClient = Mock(return_value=self.joe)
+
+        self.parser.routeFrostbitePacket(['player.onChat', 'Cucurbitaceae', 'ID_CHAT_REQUEST_RIDE', 'squad', '1', '1'])
+        self.assertEqual(1, self.parser.queueEvent.call_count)
+
+        event = self.parser.queueEvent.call_args[0][0]
+        self.assertEqual("Client Comrose", self.parser.getEventName(event.type))
+        self.assertEquals('ID_CHAT_REQUEST_RIDE', event.data)
+        self.assertEqual(self.joe, event.client)
+
+    def test_player_onChat_event_team_comrose(self):
+        self.parser.getClient = Mock(return_value=self.joe)
+
+        self.parser.routeFrostbitePacket(['player.onChat', 'Cucurbitaceae', 'ID_CHAT_THANKS', 'team', '1', ])
+        self.assertEqual(1, self.parser.queueEvent.call_count)
+
+        event = self.parser.queueEvent.call_args[0][0]
+        self.assertEqual("Client Comrose", self.parser.getEventName(event.type))
+        self.assertEquals('ID_CHAT_THANKS', event.data)
+        self.assertEqual(self.joe, event.client)
 
 class Test_punkbuster_events(BF4TestCase):
 


### PR DESCRIPTION
This commit create a new Event `EVT_CLIENT_COMROSE`. The data include the ComRose Message ID. The defined chat ids will not pass other events like `EVT_CLIENT_SAY`.

This can be used in plugins. If a player uses in the game the ComRose then will b3 trigger the event `EVT_CLIENT_COMROSE` and pass the CHAT_ID as data.

For what can you use it?
For example, B3 could be a command to confirm. 
The player chooses in his ComRose "Confirmation"
