### PR TITLE
[plugin] optional event mapping over predefined methods

### DIFF
--- a/b3/plugins/admin.py
+++ b/b3/plugins/admin.py
@@ -278,7 +278,7 @@ class AdminPlugin(b3.plugin.Plugin):
 
 
     def onStartup(self):
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_SAY'), self.onEvent)
+        self.registerEvent(self.console.getEventID('EVT_CLIENT_SAY'))
         self.registerEvent(self.console.getEventID('EVT_CLIENT_TEAM_SAY'))
         self.registerEvent(self.console.getEventID('EVT_CLIENT_SQUAD_SAY'))
         self.registerEvent(self.console.getEventID('EVT_CLIENT_PRIVATE_SAY'))


### PR DESCRIPTION
In the current **plugin** class, all the events are processed through the onEvent method. If a plugin register multiple events, the onEvent method would need to handle different situations; this will end up with 2 different situations: 
- 1st (worst one): all the code is written inside the onEvent method.
- 2nd (slighlty better one): the onEvent method invoke other functions specifically written for the event being processed (with subsequential **if else** statements matching event.type). This is the same behavior of point 1 but with written with different syntax.

I changed this behavior adding the possibility to map a specific event over a predefined plugin method during the event registration. I made this optional in order to keep backwards compatibility.
