### PR TITLE
Show thousands seperator in welcome message con. count

### DIFF
--- a/b3/plugins/welcome.py
+++ b/b3/plugins/welcome.py
@@ -141,7 +141,7 @@ class WelcomePlugin(b3.plugin.Plugin):
         if client.connected and _timeDiff > self._min_gap:
             info = {
                 'name'    : client.exactName,
-                'id'    : str(client.id),
+                'id'    : format(client.id, ','),
                 'connections' : format(client.connections, ',')
             }
 


### PR DESCRIPTION
This will not work in python versions before 2.7

I am not sure if this is an issue for you.
