### PR TITLE
alter mask_level to mediumint

### DIFF
--- a/b3/sql/b3-update-1.10.0.sql
+++ b/b3/sql/b3-update-1.10.0.sql
@@ -8,3 +8,6 @@ ALTER TABLE `xlr_playerstats` ADD `id_token` VARCHAR( 10 ) NOT NULL DEFAULT '';
 ALTER TABLE  `xlr_playerstats` CHANGE  `id`  `id` INT( 11 ) UNSIGNED NOT NULL AUTO_INCREMENT;
 ALTER TABLE  `xlr_history_monthly` CHANGE  `id`  `id` INT( 11 ) UNSIGNED NOT NULL AUTO_INCREMENT;
 ALTER TABLE  `xlr_history_weekly` CHANGE  `id`  `id` INT( 11 ) UNSIGNED NOT NULL AUTO_INCREMENT;
+
+-- fix mask_level in clients table
+ALTER TABLE `clients` CHANGE `mask_level` `mask_level` mediumint(8) unsigned NOT NULL DEFAULT '0';

--- a/b3/sql/b3.sql
+++ b/b3/sql/b3.sql
@@ -53,7 +53,7 @@ CREATE TABLE IF NOT EXISTS clients (
   pbid varchar(32) NOT NULL default '',
   name varchar(32) NOT NULL default '',
   auto_login tinyint(1) unsigned NOT NULL default '0',
-  mask_level tinyint(1) unsigned NOT NULL default '0',
+  mask_level mediumint(8) unsigned NOT NULL default '0',
   group_bits mediumint(8) unsigned NOT NULL default '0',
   greeting varchar(128) NOT NULL default '',
   time_add int(11) unsigned NOT NULL default '0',


### PR DESCRIPTION
The sql field `mask_level` save a bigger int (the group id). The current setup is wrong.
