### PR TITLE
rename db column 'mask_level' into 'mask_group_id'

### DIFF
--- a/b3.egg-info/PKG-INFO
+++ b/b3.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: b3
-Version: 1.10.0dev
+Version: 1.10.1dev
 Summary: BigBrotherBot (B3) is a cross-platform, cross-game game administration bot. Features in-game administration of game servers, multiple user access levels, and database storage. Currently include parsers for Call of Duty 1 to 8, Urban Terror (ioUrT 4.1 and 4.2), BF3, Arma II, CS:GO, Red Orchestra 2, BFBC2, MOH 2010, World of Padman, ETpro, Smokin' Guns, HomeFront, Open Arena, Altitude.
 Home-page: http://www.bigbrotherbot.net
 Author: Michael Thornton (ThorN), Tim ter Laak (ttlogic), Mark Weirath (xlr8or), Thomas Leveil (Courgette)

--- a/b3/PKG-INFO
+++ b/b3/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.1
 Name: b3
-Version: 1.10.0dev
+Version: 1.10.1dev
 Summary: BigBrotherBot (B3) is a cross-platform, cross-game game administration bot. Features in-game administration of game servers, multiple user access levels, and database storage. Currently include parsers for Call of Duty 1 to 8, Urban Terror (ioUrT 4.1 and 4.2), BF3, Arma II, CS:GO, Red Orchestra 2, BFBC2, MOH 2010, World of Padman, ETpro, Smokin' Guns, HomeFront, Open Arena, Altitude.
 Home-page: http://www.bigbrotherbot.net
 Author: Michael Thornton (ThorN), Tim ter Laak (ttlogic), Mark Weirath (xlr8or), Thomas Leveil (Courgette)

--- a/b3/clients.py
+++ b/b3/clients.py
@@ -18,6 +18,8 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 # CHANGELOG
+#    2014/01/11 - 1.7 - courgette
+#    * get rid of field maskLevel, see maskGroupId instead
 #    07/08/2013 - 1.6.1 - courgette
 #    * getting a client by its db id will return the existing client object if found in the list of connected clients
 #    15/07/2013 - 1.6 - courgette
@@ -86,7 +88,7 @@ import time
 import traceback
 
 __author__  = 'ThorN'
-__version__ = '1.6.1'
+__version__ = '1.7'
 
 
 class ClientVar(object):
@@ -128,7 +130,7 @@ class Client(object):
     ip   = ''
     greeting = ''
     autoLogin = 1
-    maskLevel = 0
+    maskGroupId = None
     groupBits = 0
     login = ''
     password = ''
@@ -329,32 +331,24 @@ class Client(object):
     connections = property(_get_connections, _set_connections)
 
     #------------------------
-    _maskLevel = 0
-    def _set_maskLevel(self, v):
-        self._maskLevel = int(v)
-
-    def _get_maskLevel(self):
-        return self._maskLevel
-
-    maskLevel = property(_get_maskLevel, _set_maskLevel)
-
-    #------------------------
     _maskGroup = None
     def _set_maskGroup(self, g):
-        self.maskLevel = g.id
-        self._maskGroup = None
+        if g is None:
+            self.maskGroupId = None
+            self._maskGroup = None
+        else:
+            self.maskGroupId = g.id
+            self._maskGroup = g
 
     def _get_maskGroup(self):
-        if not self.maskLevel:
+        if self.maskGroupId is None:
             return None
-        elif not self._maskGroup:
+        elif self._maskGroup is None:
             groups = self.console.storage.getGroups()
-
             for g in groups:
-                if g.id & self.maskLevel:
+                if g.id & self.maskGroupId:
                     self._maskGroup = g
                     break
-
         return self._maskGroup
 
     maskGroup = property(_get_maskGroup, _set_maskGroup)

--- a/b3/parsers/iourt41.py
+++ b/b3/parsers/iourt41.py
@@ -170,9 +170,11 @@
 #     * add hitlocation constants : HL_HEAD, HL_HELMET and HL_TORSO
 # 10/08/2013 - 1.18 - Fenix
 #     * change getNextMap to use CVARs only (no more mapcycle file parsing)
+# 2014/01/11 - 1.18.1 - Courgette
+#     * maskLevel -> maskGroupId to reflect changes in B3 core
 #
 __author__  = 'xlr8or, Courgette'
-__version__ = '1.18'
+__version__ = '1.18.1'
 
 import re, string, time, thread
 from b3.parsers.q3a.abstractParser import AbstractParser
@@ -677,7 +679,7 @@ class Iourt41Parser(AbstractParser):
                 for k, v in bclient.iteritems():
                     if hasattr(client, 'gear') and k == 'gear' and client.gear != v:
                         self.queueEvent(b3.events.Event(b3.events.EVT_CLIENT_GEAR_CHANGE, v, client))
-                    if not k.startswith('_') and k not in ('login', 'password', 'groupBits', 'maskLevel', 'autoLogin', 'greeting'):
+                    if not k.startswith('_') and k not in ('login', 'password', 'groupBits', 'maskGroupId', 'autoLogin', 'greeting'):
                         setattr(client, k, v)
             else:
                 #make a new client

--- a/b3/parsers/iourt42.py
+++ b/b3/parsers/iourt42.py
@@ -87,6 +87,8 @@
 #     * added EVT_CLIENT_SPAWN and EVT_FLAG_RETURN_TIME
 # 11/12/2013 - 1.20 - Courgette
 #     * fix: players with ':' in their name can't run commands ('UrT bug spotted' showing up in the log)
+# 2014/01/11 - 1.20.1 - Courgette
+#     * maskLevel -> maskGroupId to reflect changes in B3 core
 
 import re, new
 import time
@@ -98,7 +100,7 @@ from b3.events import Event
 from b3.plugins.spamcontrol import SpamcontrolPlugin
 
 __author__  = 'Courgette'
-__version__ = '1.20'
+__version__ = '1.20.1'
 
 
 class Iourt42Client(Client):
@@ -1011,7 +1013,7 @@ class Iourt42Parser(Iourt41Parser):
                 for k, v in bclient.iteritems():
                     if hasattr(client, 'gear') and k == 'gear' and client.gear != v:
                         self.queueEvent(b3.events.Event(b3.events.EVT_CLIENT_GEAR_CHANGE, v, client))
-                    if not k.startswith('_') and k not in ('login', 'password', 'groupBits', 'maskLevel', 'autoLogin', 'greeting'):
+                    if not k.startswith('_') and k not in ('login', 'password', 'groupBits', 'maskGroupId', 'autoLogin', 'greeting'):
                         setattr(client, k, v)
             else:
                 #make a new client

--- a/b3/plugins/admin.py
+++ b/b3/plugins/admin.py
@@ -17,6 +17,8 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 # CHANGELOG
+#   2014/01/11 - 1.26 - Courgette
+#   * maskLevel -> maskGroup to reflect changes in B3 core
 #   2014/01/07 - 1.25 - Courgette
 #   * removed the 'peeing in the gene pool' reason for tempbans with durations between 5 and 10 min
 #   2013/11/16 - 1.24 - Fenix
@@ -141,7 +143,7 @@
 #    Added data field to warnClient(), warnKick(), and checkWarnKick()
 #
 
-__version__ = '1.25'
+__version__ = '1.26'
 __author__ = 'ThorN, xlr8or, Courgette, Ozon'
 
 import re
@@ -762,8 +764,7 @@ class AdminPlugin(b3.plugin.Plugin):
             client.message(self.getMessage('group_unknown', {'group_name': groupName}))
             return False
 
-        sclient.maskLevel = group.id
-        sclient._maskGroup = None
+        sclient.maskGroup = group
         sclient.save()
 
         if sclient != client:
@@ -783,8 +784,7 @@ class AdminPlugin(b3.plugin.Plugin):
             sclient = self.findClientPrompt(m[0], client)
 
         if sclient:
-            sclient.maskLevel = 0
-            sclient._maskGroup = None
+            sclient.maskGroup = None
             sclient.save()
 
             if sclient != client:

--- a/b3/setup.py
+++ b/b3/setup.py
@@ -992,6 +992,13 @@ class Update(Setup):
         else:
             self.add_buffer('Version older than 1.10.0...\n')
 
+        # update to v1.10.1
+        if _currentversion >= '1.10.1':
+            self.executeSql('@b3/sql/b3-update-1.10.1.sql', _dbstring)
+            self.add_buffer('Updating database to version 1.10.1...\n')
+        else:
+            self.add_buffer('Version older than 1.10.1...\n')
+
         # need to update xlrstats?
         #_result = self.raw_default('Do you have xlrstats installed (with default table names)?', 'yes')
         #if _result == 'yes':

--- a/b3/sql/b3-update-1.10.1.sql
+++ b/b3/sql/b3-update-1.10.1.sql
@@ -1,0 +1,5 @@
+-- SQL code to update default B3 database tables to B3 version 1.10.1 --
+-- --------------------------------------------------------
+
+-- change mask_level in clients table to mask_group
+ALTER TABLE `clients` CHANGE `mask_level` `mask_group_id` mediumint(8) unsigned NOT NULL DEFAULT '0';

--- a/b3/sql/b3.sql
+++ b/b3/sql/b3.sql
@@ -53,7 +53,7 @@ CREATE TABLE IF NOT EXISTS clients (
   pbid varchar(32) NOT NULL default '',
   name varchar(32) NOT NULL default '',
   auto_login tinyint(1) unsigned NOT NULL default '0',
-  mask_level tinyint(1) unsigned NOT NULL default '0',
+  mask_group_id mediumint(8) unsigned default NULL,
   group_bits mediumint(8) unsigned NOT NULL default '0',
   greeting varchar(128) NOT NULL default '',
   time_add int(11) unsigned NOT NULL default '0',

--- a/b3/sql/sqlite/b3.sql
+++ b/b3/sql/sqlite/b3.sql
@@ -29,7 +29,7 @@ CREATE TABLE IF NOT EXISTS clients (
   pbid varchar(32) NOT NULL default '',
   name varchar(32) NOT NULL default '',
   auto_login tinyint(1) 	 NOT NULL default '0',
-  mask_level tinyint(1) 	 NOT NULL default '0',
+  mask_group_id mediumint(8) default NULL,
   group_bits mediumint(8) 	 NOT NULL default '0',
   greeting varchar(128) NOT NULL default '',
   time_add int(11) 	 NOT NULL default '0',

--- a/b3/storage/database.py
+++ b/b3/storage/database.py
@@ -17,6 +17,8 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 # CHANGELOG
+#   2014/01/11 - 1.15 - courgette
+#    rename field mask_level to mask_group_id
 #   12/08/2013 - 1.14 - courgette
 #    add method getTables()
 #   26/11/2012 - 1.13 - courgette
@@ -66,7 +68,7 @@
 #   Added data column to penalties table
 
 __author__  = 'ThorN'
-__version__ = '1.14'
+__version__ = '1.15'
 
 
 from b3 import functions
@@ -440,21 +442,6 @@ class DatabaseStorage(Storage):
         return clients
 
     def setClient(self, client):
-        """
-        id int(11)   PRI NULL auto_increment 
-        ip varchar(16) YES   NULL   
-        greeting varchar(128) YES   NULL   
-        connections int(11) YES   NULL   
-        time_edit int(11) YES   NULL   
-        guid varchar(32)   MUL     
-        pbid varchar(32) YES   NULL   
-        name varchar(32) YES   NULL   
-        time_add int(11) YES   NULL   
-        auto_login int(11) YES   NULL   
-        mask_level int(11) YES   NULL   
-        group_bits int(11) 
-        """
-
         self.console.debug('Storage: setClient %s' % client)
 
         fields = (
@@ -467,7 +454,7 @@ class DatabaseStorage(Storage):
             'name',
             'time_add',
             'auto_login',
-            'mask_level',
+            'mask_group_id',
             'group_bits',
             'login',
             'password'

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ try:
 except:
     has_py2exe = False
 
-b3version = "1.10.0dev"
+b3version = "1.10.1dev"
 
 # override egg_info command to copy the b3.egg-info/PKG-INFO file into the b3 directory
 class my_egg_info(orig_egg_info):

--- a/tests/storage/common.py
+++ b/tests/storage/common.py
@@ -23,7 +23,7 @@ class StorageAPITest(object):
     storage = None
         
     def test_setClient(self):
-        c1 = Client(ip="1.2.3.4", connections=2, guid="abcdefghijkl", pbid="123546abcdef", name="some dude", greeting="hi!", mask_level=20, group_bits=8, login="test login", password="test password")
+        c1 = Client(ip="1.2.3.4", connections=2, guid="abcdefghijkl", pbid="123546abcdef", name="some dude", greeting="hi!", mask_group_id=8, group_bits=8, login="test login", password="test password")
         c1_id = self.storage.setClient(c1)
         self.assertEqual(1, c1_id)
         c2 = self.storage.getClient(Client(id=c1_id))


### PR DESCRIPTION
See #144

In this solution, the column `mask_level` is renamed into `mask_group_id` to reflect the fact that it stores B3 group id.

Additionally:
- B3 version is bumped to `1.10.1` so we can apply a new upgrade SQL script over existing `1.10.0` compatible databases.
- the `maskLevel` property is removed from the `Client` class in favor of `maskGroup` which makes more sense in plugin code.
- and reflect that change to a hack found in the iourt4x parsers
