### PR TITLE
fix maskLevel is set with group id while it should be group level

### DIFF
--- a/b3/plugins/admin.py
+++ b/b3/plugins/admin.py
@@ -17,6 +17,8 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
 # CHANGELOG
+#   2014/01/11 - 1.25.1 - Courgette
+#   * fix maskLevel is set with group id while it should be group level
 #   2014/01/07 - 1.25 - Courgette
 #   * removed the 'peeing in the gene pool' reason for tempbans with durations between 5 and 10 min
 #   2013/11/16 - 1.24 - Fenix
@@ -141,7 +143,7 @@
 #    Added data field to warnClient(), warnKick(), and checkWarnKick()
 #
 
-__version__ = '1.25'
+__version__ = '1.25.1'
 __author__ = 'ThorN, xlr8or, Courgette, Ozon'
 
 import re
@@ -762,8 +764,7 @@ class AdminPlugin(b3.plugin.Plugin):
             client.message(self.getMessage('group_unknown', {'group_name': groupName}))
             return False
 
-        sclient.maskLevel = group.id
-        sclient._maskGroup = None
+        sclient.maskLevel = group.level
         sclient.save()
 
         if sclient != client:
@@ -784,7 +785,6 @@ class AdminPlugin(b3.plugin.Plugin):
 
         if sclient:
             sclient.maskLevel = 0
-            sclient._maskGroup = None
             sclient.save()
 
             if sclient != client:

--- a/tests/plugins/test_admin_functional.py
+++ b/tests/plugins/test_admin_functional.py
@@ -369,6 +369,51 @@ class Cmd_mask(Admin_functional_test):
         self.joe.says('!admins')
         self.joe.message.assert_called_with('^7Admins online: Joe^7^7 [^3100^7], Mike^7^7 [^380^7]')
 
+    def _test_persistence_for_group(self, group_keyword):
+        """
+        Makes sure that a user with group 'superadmin', when masked as the given group is still masked with
+        that given group once he reconnects. Hence making sure we persists the mask group between connections.
+        :param group_keyword: str
+        """
+        group_to_mask_as = self.console.storage.getGroup(Group(keyword=group_keyword))
+        self.assertIsNotNone(group_to_mask_as)
+        ## GIVEN that joe masks himself
+        self.joe.connects(0)
+        self.joe.says('!mask ' + group_keyword)
+        self.assertEqual(128, self.joe.maxGroup.id)
+        self.assertEqual(100, self.joe.maxGroup.level)
+        self.assertIsNotNone(self.joe.maskGroup, "expecting Joe to have a masked group")
+        self.assertEqual(group_to_mask_as.id, self.joe.maskGroup.id, "expecting Joe2 to have %s for the mask group id" % group_to_mask_as.id)
+        self.assertEqual(group_to_mask_as.level, self.joe.maskGroup.level, "expecting Joe2 to have %s for the mask group level" % group_to_mask_as.level)
+        self.assertEqual(group_to_mask_as.id, self.joe.maskedGroup.id, "expecting Joe2 to have %s for the masked group id" % group_to_mask_as.id)
+        self.assertEqual(group_to_mask_as.level, self.joe.maskedGroup.level, "expecting Joe2 to have %s for the masked group level" % group_to_mask_as.level)
+        ## WHEN joe reconnects
+        self.joe.disconnects()
+        client = self.console.storage.getClient(Client(id=self.joe.id))
+        joe2 = FakeClient(self.console, **client.__dict__)
+        joe2.connects(1)
+        ## THEN joe is still masked
+        self.assertEqual(128, joe2.maxGroup.id)
+        self.assertEqual(100, joe2.maxGroup.level)
+        self.assertIsNotNone(joe2.maskGroup, "expecting Joe2 to have a masked group")
+        self.assertEqual(group_to_mask_as.id, joe2.maskGroup.id, "expecting Joe2 to have %s for the mask group id" % group_to_mask_as.id)
+        self.assertEqual(group_to_mask_as.level, joe2.maskGroup.level, "expecting Joe2 to have %s for the mask group level" % group_to_mask_as.level)
+        self.assertEqual(group_to_mask_as.id, joe2.maskedGroup.id, "expecting Joe2 to have %s for the masked group id" % group_to_mask_as.id)
+        self.assertEqual(group_to_mask_as.level, joe2.maskedGroup.level, "expecting Joe2 to have %s for the masked group level" % group_to_mask_as.level)
+        ## THEN the content of the mask_level column in the client table must be correct
+        client_data = self.console.storage.getClient(Client(id=joe2.id))
+        self.assertIsNotNone(client_data)
+        self.assertEqual(group_to_mask_as.level, client_data._maskLevel, "expecting %s to be the value in the mask_level column in database" % group_to_mask_as.level)
+
+    def test_persistence(self):
+        self._test_persistence_for_group("user")
+        self._test_persistence_for_group("reg")
+        self._test_persistence_for_group("mod")
+        self._test_persistence_for_group("admin")
+        self._test_persistence_for_group("fulladmin")
+        self._test_persistence_for_group("senioradmin")
+        self._test_persistence_for_group("superadmin")
+
 
 class Cmd_makereg_unreg(Admin_functional_test):
     def setUp(self):
@@ -816,7 +861,7 @@ no_admins: no admins
 [commands]
 admins: user
 [messages]
-no_admins: 
+no_admins:
 """)
         self.mike.connects(0)
         # only user Mike is connected


### PR DESCRIPTION
See #144

In this solution, the db column `mask_level` remains but gets valuated with group levels instead of group ids as its name suggests
