### PR TITLE
[BF4] R27 add player.on disconnect event

### DIFF
--- a/b3/parsers/bf4.py
+++ b/b3/parsers/bf4.py
@@ -24,6 +24,7 @@
 # 1.4.1, 1.6, 1.9, 1.10
 #
 # CHANGELOG
+#  v1.0.2   : forward server event player.onDisconnect to EVT_CLIENT_DISCONNECT_REASON
 #  v1.0.1   : update to server version R13 that include DLC1 (China Rising) map pack
 #  v1.0.0   : functional parser implementation based on the BF3 parser
 #
@@ -38,7 +39,7 @@ from time import sleep
 from b3.parsers.frostbite2.protocol import CommandFailedError, CommandUnknownCommandError, CommandDisallowedError
 
 __author__ = 'Courgette, ozon, Dwarfer'
-__version__ = '1.0.1'
+__version__ = '1.0.2'
 
 BF4_REQUIRED_VERSION = 111118
 
@@ -289,6 +290,7 @@ class Bf4Parser(AbstractParser):
 
         # create event for comrose actions
         self.Events.createEvent('EVT_CLIENT_COMROSE', 'Client Comrose')
+        self.Events.createEvent('EVT_CLIENT_DISCONNECT_REASON', 'Client disconnected')
 
         # create the 'Server' client
         self.clients.newClient('Server', guid='Server', name='Server', hide=True, pbid='Server', team=b3.TEAM_UNKNOWN, squad=None)
@@ -400,12 +402,10 @@ class Bf4Parser(AbstractParser):
         # We receive this event if a player disconnects from the game. If a player lave the game, the reason is empty.
         # The "reason" may contain an error id or a kick/ban reason.
         # Example from server:['player.onDisconnect', 'O2ON', 'PLAYER_CONN_LOST']
-
-        client = self.clients.getByCID(data[0])
+        client = self.getClient(data[0])
         reason = data[1]
 
-        # todo: forward this event to b3
-        pass
+        self.queueEvent(b3.events.Event(b3.events.EVT_CLIENT_DISCONNECT_REASON, reason, client=client))
 
     def _OnServerLevelstarted(self, action, data):
         """

--- a/tests/parsers/test_bf4.py
+++ b/tests/parsers/test_bf4.py
@@ -345,6 +345,18 @@ class Test_bf4_events(BF4TestCase):
         self.assertEquals('ID_CHAT_THANKS', event.data)
         self.assertEqual(self.joe, event.client)
 
+    def test_player_onDisconnect_event(self):
+        self.parser.getClient = Mock(return_value=self.joe)
+
+        self.parser.routeFrostbitePacket(['player.onDisconnect', 'Cucurbitaceae', 'test'])
+        self.assertEqual(1, self.parser.queueEvent.call_count)
+
+        event = self.parser.queueEvent.call_args[0][0]
+        print event.client.name
+        self.assertEqual('Client disconnected', self.parser.getEventName(event.type))
+        self.assertEquals('test', event.data)
+        self.assertEqual(self.joe, event.client)
+
 class Test_punkbuster_events(BF4TestCase):
 
     def setUp(self):


### PR DESCRIPTION
- update version to R27
- forward `player.onDisconnect` to `EVT_CLIENT_DISCONNECT_REASON` (#169)
- add test
