### PR TITLE
Allow COD5 minimum guid length to be user specified in b3 xml

### DIFF
--- a/b3/parsers/cod.py
+++ b/b3/parsers/cod.py
@@ -68,9 +68,10 @@
 #                                        - correctly initialize variables before usage
 # 30/07/2014 - 1.4.32   - Fenix          - fixes for the new getWrap implementation
 # 03/08/2014 - 1.5      - Fenix          - syntax cleanup
+# 15/10/2014 - 1.5.1    - 82ndab.Bravo17 - show current minimum guid length if one that is too short is found
 
 __author__ = 'ThorN, xlr8or'
-__version__ = '1.5'
+__version__ = '1.5.1'
 
 
 import b3
@@ -411,7 +412,7 @@ class CodParser(AbstractParser):
         name = match.group('name')
         if len(codguid) < self._guidLength:
             # invalid guid
-            self.verbose2('Invalid GUID: %s' % codguid)
+            self.verbose2('Invalid GUID: %s. GUID length set to %s' % (codguid, self._guidLength))
             codguid = None
 
         client = self.getClient(match)

--- a/b3/parsers/cod5.py
+++ b/b3/parsers/cod5.py
@@ -39,9 +39,10 @@
 # 30/07/2014 - 1.3.4 - Fenix          - fixes for the new getWrap implementation
 # 29/08/2014 - 1.3.5 - 82ndab.Bravo17 - reduce min guid length to 8
 # 04/08/2014 - 1.4   - Fenix          - syntax cleanup
+# 15/10/2014 - 1.4.1 - 82ndab.Bravo17 - allow minimum guid length to be set in b3 xml, guid_length in b3 section
 
 __author__ = 'xlr8or'
-__version__ = '1.4'
+__version__ = '1.4.1'
 
 import b3.functions
 import b3.parsers.cod2
@@ -96,6 +97,11 @@ class Cod5Parser(b3.parsers.cod2.Cod2Parser):
         """
         self.patch_b3_admin_plugin()
         self.debug('Admin plugin has been patched')
+
+        if self.config.has_option('b3', 'guid_length'):
+            self._guidLength = self.config.getint('b3', 'guid_length')
+            self.info('Min guid length has been set to %s', self._guidLength)
+
     
     ####################################################################################################################
     ##                                                                                                                ##


### PR DESCRIPTION
This will allow cod5 users to specify that they will accept smaller guid's than currently accepted by the parser
