### PR TITLE
[IOURT42] allow client search using auth login as handle

### DIFF
--- a/b3/parsers/iourt42.py
+++ b/b3/parsers/iourt42.py
@@ -85,6 +85,8 @@
 # 17/09/2014 - 1.26.1 - Fenix     - added missing Freeze Tag gametype declaration (10) in defineGametype()
 # 02/10/2014 - 1.27   - Fenix     - fixed regression introduced in 1.25
 # 12/12/2014 - 1.28   - Fenix     - increased chat line length to comply with the new HUD setting (4.2.021)
+# 25/01/2015 - 1.29   - Fenix     - patch the b3.clients.getByMagic method so it's possible to lookup players using their
+#                                   auth login
 
 import b3
 import re
@@ -1326,18 +1328,17 @@ class Iourt42Parser(Iourt41Parser):
 
     @staticmethod
     def patch_Clients():
-        """
-        Patch the new_client method in the Client class
-        to handle UrT 4.2 specific client instances.
-        """
+
         def newClient(self, cid, **kwargs):
+            """
+            Patch the newClient method in the Clients class to handle UrT 4.2 specific client instances.
+            """
             client = Iourt42Client(console=self.console, cid=cid, timeAdd=self.console.time(), **kwargs)
             self[client.cid] = client
             self.resetIndex()
 
-            self.console.debug('Urt42 Client Connected: [%s] %s - %s (%s)',
-                               self[client.cid].cid, self[client.cid].name,
-                               self[client.cid].guid, self[client.cid].data)
+            self.console.debug('Urt42 Client Connected: [%s] %s - %s (%s)',  self[client.cid].cid, self[client.cid].name,
+                                                                             self[client.cid].guid, self[client.cid].data)
 
             self.console.queueEvent(self.console.getEvent('EVT_CLIENT_CONNECT', data=client, client=client))
 
@@ -1347,4 +1348,31 @@ class Iourt42Parser(Iourt41Parser):
                 self.authorizeClients()
             return client
 
+        def newGetByMagic(self, handle):
+            """
+            Patch the getByMagic method in the Clients class so it's possible to lookup players using the auth login.
+            """
+            handle = handle.strip()
+            if re.match(r'^[0-9]+$', handle):
+                client = self.getByCID(handle)
+                if client:
+                    return [client]
+                return []
+            elif re.match(r'^@([0-9]+)$', handle):
+                return self.getByDB(handle)
+            elif handle[:1] == '\\':
+                c = self.getByName(handle[1:])
+                if c and not c.hide:
+                    return [c]
+                return []
+            else:
+                clients = []
+                needle = re.sub(r'\s', '', handle.lower())
+                for cid, c in self.items():
+                    cleanname = re.sub(r'\s', '', c.name.lower())
+                    if not c.hide and (needle in cleanname or needle in c.pbid) and not c in clients:
+                        clients.append(c)
+                return clients
+
         b3.clients.Clients.newClient = newClient
+        b3.clients.Clients.getByMagic = newGetByMagic

--- a/b3/parsers/iourt42.py
+++ b/b3/parsers/iourt42.py
@@ -101,7 +101,7 @@ from b3.plugins.spamcontrol import SpamcontrolPlugin
 
 
 __author__ = 'Courgette, Fenix'
-__version__ = '1.28'
+__version__ = '1.29'
 
 
 class Iourt42Client(Client):

--- a/tests/parsers/test_iourt42.py
+++ b/tests/parsers/test_iourt42.py
@@ -1419,3 +1419,40 @@ class Test_load_conf_tempban_with_frozensand(Test_config):
         self.assertFalse(self.console._tempban_with_frozensand)
 
 
+class Test_newGetByMagic(Iourt42TestCase):
+
+    def setUp(self):
+        Iourt42TestCase.setUp(self)
+        self.console.startup()
+        self.mike = FakeClient(self.console, name="Mike", guid="000000000000000", pbid="wizard")
+        self.john = FakeClient(self.console, name="John", guid="111111111111111", pbid="miles")
+        self.matt = FakeClient(self.console, name="Matt", guid="222222222222222", pbid="johndoe")
+        self.mark = FakeClient(self.console, name="Mark", guid="333333333333333", pbid="markus")
+        self.mike.connects("1")
+        self.john.connects("2")
+        self.matt.connects("3")
+        self.mark.connects("4")
+
+    def test_get_by_name(self):
+        # WHEN
+        clients = self.console.clients.getByMagic("mike")
+        # THEN
+        self.assertListEqual(clients, [self.mike])
+
+    def test_get_by_pbid(self):
+        # WHEN
+        clients = self.console.clients.getByMagic("miles")
+        # THEN
+        self.assertListEqual(clients, [self.john])
+
+    def test_get_by_name_and_pbid(self):
+        # WHEN
+        clients = self.console.clients.getByMagic("jo")
+        # THEN
+        self.assertListEqual(clients, [self.matt, self.john])
+
+    def test_empty_set(self):
+        # WHEN
+        clients = self.console.clients.getByMagic("asd")
+        # THEN
+        self.assertListEqual(clients, [])


### PR DESCRIPTION
This pull request carries a patch added by the `iourt42` parser to the `b3.clients.Clients` class: I changed the `getByMagic` method to perform search also using the client auth login (`pbid` field) which is visible in the scoreboard. The method works as before, but when performing the search using player names it will also match the `pbid` field.