### PR TITLE
minor fix to pluginImport

### DIFF
--- a/b3/cron.py
+++ b/b3/cron.py
@@ -37,7 +37,7 @@ import traceback
 import sys
 
 
-class ReMatcher:
+class ReMatcher(object):
 
     _re = None
 
@@ -162,8 +162,9 @@ class CronTab(object):
             return int(rate)
 
         raise TypeError('"%s" is not a known cron rate type' % rate)
-    
-    def _getRateFromFragment(self, rate, maxrate):
+
+    @staticmethod
+    def _getRateFromFragment(rate, maxrate):
         r = ReMatcher()
         if rate == '*':
             return -1
@@ -195,8 +196,9 @@ class CronTab(object):
             return range(lmin, lmax + 1, step)
 
         raise TypeError('"%s" is not a known cron rate type' % rate)
-    
-    def _match(self, unit, value):
+
+    @staticmethod
+    def _match(unit, value):
         if type(unit) == int:
             if unit == -1 or unit == value:
                 return True
@@ -281,7 +283,7 @@ class Cron(object):
         Add a CronTab to the list of active cron tabs.
         """
         self._tabs[id(tab)] = tab
-        self.console.verbose('added crontab %s (%s) - %ss %sm %sh %sd %sM %sDOW' % (tab.command, id(tab), tab.second,
+        self.console.verbose('Added crontab %s (%s) - %ss %sm %sh %sd %sM %sDOW' % (tab.command, id(tab), tab.second,
                                                                                     tab.minute, tab.hour, tab.day,
                                                                                     tab.month, tab.dow))
         return id(tab)
@@ -292,9 +294,9 @@ class Cron(object):
         """
         try:
             del self._tabs[tab_id]
-            self.console.verbose('removed crontab %s' % tab_id)
+            self.console.verbose('Removed crontab %s' % tab_id)
         except KeyError:
-            self.console.verbose('crontab %s not found' % tab_id)
+            self.console.verbose('Crontab %s not found' % tab_id)
 
     def __add__(self, tab):
         self.add(tab)
@@ -308,7 +310,8 @@ class Cron(object):
         """
         thread.start_new_thread(self.run, ())
 
-    def time(self):
+    @staticmethod
+    def time():
         """
         Return the current timestamp.
         """
@@ -325,7 +328,7 @@ class Cron(object):
         Main cron loop.
         Will terminate when stop event is set.
         """
-        self.console.info("cron scheduler started")
+        self.console.info("Cron scheduler started")
         nexttime = self.getNextTime()
         while not self._stopEvent.isSet():
             now = self.time()
@@ -348,13 +351,14 @@ class Cron(object):
                         try:
                             c.run()
                         except Exception, msg:
-                            self.console.error('exception raised while executing crontab %s: %s\n%s', c.command,
+                            self.console.error('Exception raised while executing crontab %s: %s\n%s', c.command,
                                                msg, traceback.extract_tb(sys.exc_info()[2]))
             nexttime += 1
 
-        self.console.info("cron scheduler ended")
+        self.console.info("Cron scheduler ended")
 
-    def getNextTime(self):
+    @staticmethod
+    def getNextTime():
         # store the time first, we don't want it to change on us
         t = time.time()
         # current time, minus it's 1 second remainder, plus 1 seconds

--- a/b3/parser.py
+++ b/b3/parser.py
@@ -1246,7 +1246,7 @@ class Parser(object):
         if not hasattr(event, 'type'):
             return False
         elif event.type in self._handlers.keys():  # queue only if there are handlers to listen for this event
-            self.verbose('Queueing event %s %s', self.Events.getName(event.type), event.data)
+            self.verbose('Queueing event %s : %s', self.Events.getName(event.type), event.data)
             try:
                 time.sleep(0.001)  # wait a bit so event doesnt get jumbled
                 self.queue.put((self.time(), self.time() + expire, event), True, 2)

--- a/b3/parsers/iourt42.py
+++ b/b3/parsers/iourt42.py
@@ -217,10 +217,9 @@ class Iourt42Client(Client):
 
             if in_storage:
                 self.lastVisit = self.timeEdit
-                self.console.bot('Client found in the storage @%s: '
-                                 'welcome back %s (FSA: %s)', self.id, self.name, self.pbid)
+                self.console.bot("Client found in the storage @%s: welcome back %s [FSA: '%s']", self.id, self.name, self.pbid)
             else:
-                self.console.bot('Client not found in the storage %s (FSA: %s), create new', str(self.guid), self.pbid)
+                self.console.bot("Client not found in the storage %s [FSA: '%s'], create new", str(self.guid), self.pbid)
 
             self.connections = int(self.connections) + 1
             self.name = name
@@ -230,7 +229,7 @@ class Iourt42Client(Client):
             self.save()
             self.authed = True
 
-            self.console.debug('Client authorized: @%s "%s" [%s] (FSA: %s)', self.cid, self.name, self.guid, self.pbid)
+            self.console.debug("Client authorized: %s [@%s] [GUID: '%s'] [FSA: '%s']", self.name, self.cid, self.guid, self.pbid)
 
             # check for bans
             if self.numBans > 0:

--- a/b3/tools/documentationBuilder.py
+++ b/b3/tools/documentationBuilder.py
@@ -294,7 +294,7 @@ class DocBuilder:
             
         dsn = splitDSN(self._outputUrl)
         if dsn['protocol'] == 'ftp':
-            self._console.debug('uploading to FTP server %s' % dsn['host'])
+            self._console.debug('AUTODOC: uploading to FTP server %s' % dsn['host'])
             ftp = FTP(dsn['host'], dsn['user'], passwd=dsn['password'])
             ftp.cwd(os.path.dirname(dsn['path']))
             ftpfile = StringIO.StringIO()
@@ -302,7 +302,7 @@ class DocBuilder:
             ftpfile.seek(0)
             ftp.storbinary('STOR ' + os.path.basename(dsn['path']), ftpfile)
         elif dsn['protocol'] == 'file':
-            self._console.debug('writing to %s', dsn['path'])
+            self._console.debug('AUTODOC: writing to %s', dsn['path'])
             f = file(dsn['path'], 'w')
             f.write(text)
             f.close()


### PR DESCRIPTION
This pull request carries a minor fix to the `Parser` method `pluginImport`: the method was not raising `ImportError` when it couldn't load a module from a specific path; it was logging the error and returning `None` which was causing an `AttributeError` being raised in `loadPlugins` (so a duplicated exception was being logged).

I also updated some log messages (mostly case correction and some debug messages moved to verbose)