### PR TITLE
status plugin fix + added optional logsize configuration value to main b3 config

### DIFF
--- a/b3/conf/b3.distribution.ini
+++ b/b3/conf/b3.distribution.ini
@@ -101,4 +101,4 @@ welcome: @conf/plugin_welcome.ini
 # This is a non-standard plugin, and quite resource heavy. Please take
 # a look in the B3 forums (look for XLR Extensions) for more
 # information before enabling this. Extra database tables are necessary.
-#xlrstats: @b3/extplugins/conf/plugin_xlrstats.ini
+#xlrstats: @b3/extplugins/xlrstats/conf/plugin_xlrstats.ini

--- a/b3/conf/b3.distribution.ini
+++ b/b3/conf/b3.distribution.ini
@@ -22,9 +22,6 @@ log_level: 9
 # Name of the logfile the bot will generate
 logfile: b3.log
 # Comma separated list of plugins that will be loaded in 'disabled' status.
-# Example: if you want b3 to load the 'stats' and 'pingwatch' plugin but not to start them at b3 main run,
-# the following line should be >>> disabled_plugins: stats, pingwatch.
-# NOTE: if you specify here the name of a plugin which is not being loaded, B3 will simply discard it
 disabled_plugins:
 # The directory where additional plugins can be found
 external_plugins_dir: @b3/extplugins

--- a/b3/functions.py
+++ b/b3/functions.py
@@ -44,9 +44,10 @@
 #                                     - added hash_file function: calculate the MD5 digest of the given file
 # 20/12/2014 - 1.15  - Fenix          - fixed hash_file returning None
 # 27/12/2014 - 1.16  - Fenix          - adapted splitDSN to support postgresql databases
+# 04/02/2015 - 1.17  - Fenix          - added getBytes function
 
 __author__    = 'ThorN, xlr8or, courgette'
-__version__   = '1.16'
+__version__   = '1.17'
 
 import collections
 import os
@@ -573,3 +574,45 @@ def unzip(filepath, directory):
         mkdir(directory)
         with zipfile.ZipFile(filepath, 'r') as z:
             z.extractall(directory)
+
+
+def getBytes(size):
+    """
+    Convert the given size in the correspondent amount of bytes.
+    :param size: The size we want to convert in bytes
+    :raise TypeError: If an invalid input is given
+    :return: The given size converted in bytes
+    >>> getBytes(10)
+    10
+    >>> getBytes('10')
+    10
+    >>> getBytes('1KB')
+    1024
+    >>> getBytes('1K')
+    1024
+    >>> getBytes('1MB')
+    1048576
+    >>> getBytes('1M')
+    1048576
+    >>> getBytes('1GB')
+    1073741824
+    >>> getBytes('1G')
+    1073741824
+    """
+    size = str(size).upper()
+    r = re.compile(r'''^(?P<size>\d+)\s*(?P<mult>KB|MB|GB|TB|K|M|G|T?)$''')
+    m = r.match(size)
+    if not m:
+        raise TypeError('invalid input given: %s' % size)
+
+    multipliers = {
+        'K': 1024, 'KB': 1024,
+        'M': 1048576, 'MB': 1048576,
+        'G': 1073741824, 'GB': 1073741824,
+        'T': 1099511627776, 'TB': 1099511627776,
+    }
+
+    try:
+        return int(m.group('size')) * multipliers[m.group('mult')]
+    except KeyError:
+        return int(m.group('size'))

--- a/b3/output.py
+++ b/b3/output.py
@@ -24,6 +24,7 @@
 # 20/04/2011 - 1.6.1 - Courgette - should get rid of UnicodeDecodeError
 # 20/04/2011 - 1.6.2 - Courgette - again getting rid of UnicodeDecodeError
 # 21/07/2014 - 1.7   - Fenix     - syntax cleanup
+# 04/02/2015 - 1.7.1 - Fenix     - getInstance() now accepts an optional 'logsize' parameter (amount of bytes of the log file)
 
 __author__  = 'ThorN'
 __version__ = '1.7'
@@ -147,11 +148,12 @@ logging.setLoggerClass(OutputHandler)
 
 __output = None
 
-def getInstance(logfile='b3.log', loglevel=21, log2console=False):
+def getInstance(logfile='b3.log', loglevel=21, logsize=10485760, log2console=False):
     """
     Return a Logger instance.
     :param logfile: The logfile name.
     :param loglevel: The logging level.
+    :param logsize: The size of the log file (in bytes)
     :log2console: Whether or not to extend logging to the console.
     """
     global __output
@@ -163,7 +165,7 @@ def getInstance(logfile='b3.log', loglevel=21, log2console=False):
 
         # add the log file handler
         file_formatter = logging.Formatter('%(asctime)s\t%(levelname)s\t%(message)r', '%y%m%d %H:%M:%S')
-        handler = handlers.RotatingFileHandler(logfile, maxBytes=10485760, backupCount=5, encoding="UTF-8")
+        handler = handlers.RotatingFileHandler(logfile, maxBytes=logsize, backupCount=5, encoding="UTF-8")
         handler.doRollover()
         handler.setFormatter(file_formatter)
 

--- a/b3/output.py
+++ b/b3/output.py
@@ -27,7 +27,7 @@
 # 04/02/2015 - 1.7.1 - Fenix     - getInstance() now accepts an optional 'logsize' parameter (amount of bytes of the log file)
 
 __author__  = 'ThorN'
-__version__ = '1.7'
+__version__ = '1.7.1'
 
 import sys
 import logging

--- a/b3/parser.py
+++ b/b3/parser.py
@@ -18,6 +18,7 @@
 #
 # CHANGELOG
 #
+# 2015/02/04 - 1.41.6 - Fenix           - optionally specify a log file size: 'logsize' option in 'b3' section of main cfg
 # 2015/02/02 - 1.41.5 - 82ndab.Bravo17  - Remove color codes at start of getWrap if not valid for game
 # 2015/01/29 - 1.41.4 - Fenix           - do not let plugins crash B3 by raising an exception within the constructor
 #                                       - fixed KeyError beiung raised in loadPlugins()
@@ -201,6 +202,7 @@ from b3.functions import getModule
 from b3.functions import vars2printf
 from b3.functions import main_is_frozen
 from b3.functions import splitDSN
+from b3.functions import getBytes
 from b3.functions import right_cut
 from textwrap import TextWrapper
 
@@ -365,7 +367,12 @@ class Parser(object):
         log2console = self.config.has_option('devmode', 'log2console') and \
             self.config.getboolean('devmode', 'log2console')
 
-        self.log = b3.output.getInstance(logfile, self.config.getint('b3', 'log_level'), log2console)
+        try:
+            logsize = self.config.get('b3', 'logsize')
+        except (TypeError, NoOptionError):
+            logsize = getBytes('10MB')
+
+        self.log = b3.output.getInstance(logfile, self.config.getint('b3', 'log_level'), logsize, log2console)
 
         # save screen output to self.screen
         self.screen = sys.stdout

--- a/b3/parser.py
+++ b/b3/parser.py
@@ -368,7 +368,7 @@ class Parser(object):
             self.config.getboolean('devmode', 'log2console')
 
         try:
-            logsize = self.config.get('b3', 'logsize')
+            logsize = getBytes(self.config.get('b3', 'logsize'))
         except (TypeError, NoOptionError):
             logsize = getBytes('10MB')
 

--- a/b3/parser.py
+++ b/b3/parser.py
@@ -168,7 +168,7 @@
 #                                       - added warning, info, exception, and critical log handlers
 
 __author__ = 'ThorN, Courgette, xlr8or, Bakes, Ozon, Fenix'
-__version__ = '1.41.5'
+__version__ = '1.41.6'
 
 
 import os

--- a/tests/plugins/test_status.py
+++ b/tests/plugins/test_status.py
@@ -49,7 +49,7 @@ class Test_config(B3TestCase):
             [settings]
             interval: 60
             output_file: ~/status.xml
-            enableDBsvarSaving: no
+            enableDBsvarSaving: yes
             enableDBclientSaving: no
             svar_table: alternate_svar_table
             """))
@@ -83,7 +83,7 @@ class Test_config(B3TestCase):
             interval: 60
             output_file: ~/status.xml
             enableDBsvarSaving: no
-            enableDBclientSaving: no
+            enableDBclientSaving: yes
             client_table: alternate_client_table
             """))
         self.p = StatusPlugin(self.console, conf)

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -16,8 +16,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 #
-import time
-import sys
+
 from b3 import functions
 import unittest2 as unittest
     
@@ -140,6 +139,7 @@ class TestTime2minutes(unittest.TestCase):
         self.assertEqual(functions.time2minutes('90w'), 90*7*24*60)
 
 class Test_misc(unittest.TestCase):
+
     def test_minutesStr(self):
         for test_data, expected in {
             '3s': '3 seconds',
@@ -194,6 +194,17 @@ class Test_misc(unittest.TestCase):
             if expected != result:
                 self.fail("%r, expecting '%s' but got '%s'" % (test_data, expected, result))
 
+    def test_getBytes(self):
+        self.assertEqual(10, functions.getBytes(10))
+        self.assertEqual(10, functions.getBytes('10'))
+        self.assertEqual(1024, functions.getBytes('1KB'))
+        self.assertEqual(1024, functions.getBytes('1k'))
+        self.assertEqual(2048, functions.getBytes('2kb'))
+        self.assertEqual(2048, functions.getBytes('2K'))
+        self.assertEqual(1048576, functions.getBytes('1 m'))
+        self.assertEqual(7340032, functions.getBytes('7 MB'))
+        self.assertEqual(21474836480, functions.getBytes('20GB'))
+        self.assertEqual(2199023255552, functions.getBytes('2T'))
 
 class Test_getStuffSoundingLike(unittest.TestCase):
 
@@ -215,4 +226,3 @@ class Test_getStuffSoundingLike(unittest.TestCase):
 
     def test_fallback(self):
         self.assertListEqual(['bar', 'william', 'joe', 'averell', 'foO', 'jack'], functions.getStuffSoundingLike('xxx', ['bar', 'foO', 'joe', 'jack', 'averell', 'william']))
-


### PR DESCRIPTION
This PR carries a fix to the status plugin which was not writing XML status when database options were both disabled:

```
150202 20:12:00	ERROR	'Exception raised while executing crontab <bound method StatusPlugin.update of <b3.plugins.status.StatusPlugin instance at 0x15dc878>>: "could not find table \'current_svars\' in the database"\n[(\'/home/servers/resources/bigbrotherbot/b3/cron.py\', 352, \'run\', \'c.run()\'), (\'/home/servers/resources/bigbrotherbot/b3/cron.py\', 260, \'run\', \'CronTab.run(self)\'), (\'/home/servers/resources/bigbrotherbot/b3/cron.py\', 89, \'run\', \'self.command()\'), (\'/home/servers/resources/bigbrotherbot/b3/plugins/status/__init__.py\', 364, \'update\', "self.console.storage.truncateTable(self._tables[\'svars\'])"), (\'/home/servers/resources/bigbrotherbot/b3/storage/mysql.py\', 356, \'truncateTable\', \'raise KeyError("could not find table \\\'%s\\\' in the database" % table)\')]'
```

I also added an optional logsize configuration value to main b3 config (section 'b3') which allow users to specify the maximum size of each rotating log file (default to 10MB). The input format is being converted through a new `getBytes` function i added to `b3.functions` (example of accepted input: https://github.com/danielepantaleone/big-brother-bot/commit/cf95e10e6c42823273c391618afe228a4ab413ac#diff-d13b7abad49866448d5d5161bcd4c099R579)
