### PR TITLE
Fix spectator team not recognized

### DIFF
--- a/b3/parsers/csgo.py
+++ b/b3/parsers/csgo.py
@@ -891,8 +891,8 @@ class CsgoParser(Parser):
             return TEAM_BLUE
         elif team == "CT":
             return TEAM_RED
-        #elif team = "???": # TODO find out what the spec team is
-        #    return TEAM_SPEC
+        elif team == "Spectator":
+            return TEAM_SPEC
         else:
             self.debug("unexpected team id : %s" % team)
             return TEAM_UNKNOWN


### PR DESCRIPTION
The team spectator was not recognized:
150210 18:09:50 CONSOLE 'L 02/10/2015 - 18:09:50:
"test<8><STEAM_1:1:><Spectator>" say "test"'
150210 18:09:50 DEBUG u'unexpected team id : Spectator'

I hope i chose the correct release this time..