### PR TITLE
[PARSER] make game log reading work properly in osx

### DIFF
--- a/b3/parser.py
+++ b/b3/parser.py
@@ -169,7 +169,7 @@
 #                                       - added warning, info, exception, and critical log handlers
 
 __author__ = 'ThorN, Courgette, xlr8or, Bakes, Ozon, Fenix'
-__version__ = '1.41.1'
+__version__ = '1.41.7'
 
 
 import os


### PR DESCRIPTION
Problem described here: http://forum.bigbrotherbot.net/installation-support/b3-still-not-responding/. 
I applied the patch suggested by @thomasleveil which apparently gave a good result. 
I avoided to use an if-else statement inside `read()` since the function is being called quite frequently and that if-else would have been executed everytime (while just once is needed).