### PR TITLE
plugin dependency loading

### DIFF
--- a/b3/config.py
+++ b/b3/config.py
@@ -48,22 +48,28 @@
 # 22/01/2015 - 1.7.3 - Fenix     - added add_comment method to CfgConfigParser and overridden write() method
 #                                  to properly write comments in a newly generated configuration file
 # 03/03/2015 - 1.7.4 - Fenix     - removed python 2.6 support
+# 03/03/2015 - 1.7.5 - Fenix     - moved exception classes in a separate module
 
 
 __author__  = 'ThorN, Courgette, Fenix'
-__version__ = '1.7.4'
+__version__ = '1.7.5'
 
 import os
 import re
 import time
 import b3
 import b3.functions
+import b3.exceptions
 import ConfigParser
 
 try:
     from xml.etree import cElementTree as ElementTree
 except ImportError:
     from xml.etree import ElementTree
+
+
+ConfigFileNotFound = b3.exceptions.ConfigFileNotFound
+ConfigFileNotValid = b3.exceptions.ConfigFileNotValid
 
 # list of plugins that cannot be loaded as disabled from configuration file
 MUST_HAVE_PLUGINS = ('admin', 'publist', 'ftpytail', 'sftpytail', 'httpytail')
@@ -423,28 +429,6 @@ def load(filename):
 
     # return the config if it can be loaded
     return config if config.load(filename) else None
-
-
-class ConfigFileNotFound(Exception):
-    """
-    Raised whenever the configuration file can't be found.
-    """
-    def __init__(self, message):
-        Exception.__init__(self, message)
-        
-    def __str__(self):
-        return repr(self.message)
-
-
-class ConfigFileNotValid(Exception):
-    """
-    Raised whenever we are parsing an invalid configuration file.
-    """
-    def __init__(self, message):
-        Exception.__init__(self, message)
-        
-    def __str__(self):
-        return repr(self.message)
 
 
 class MainConfig(B3ConfigParserMixin):

--- a/b3/events.py
+++ b/b3/events.py
@@ -31,9 +31,11 @@
 # 15/04/2014 - 1.5.1 - Fenix        - PEP8 coding standards
 # 21/07/2014 - 1.6   - Fenix        - syntax cleanup
 # 09/08/2014 - 1.7   - Courgette    - define new event EVT_CLIENT_TEAM_CHANGE2
+# 09/03/2014 - 1.8   - Fenix        - added EVT_PLUGIN_ENABLED, EVT_PLUGIN_DISABLED, EVT_PLUGIN_LOADED,
+#                                     EVT_PLUGIN_UNLOADED
 
 __author__ = 'ThorN, xlr8or, Courgette'
-__version__ = '1.7'
+__version__ = '1.8'
 
 import b3
 import re
@@ -59,6 +61,10 @@ class Events:
             ('EVT_STOP', 'Stop Process'),
             ('EVT_UNKNOWN', 'Unknown Event'),
             ('EVT_CUSTOM', 'Custom Event'),
+            ('EVT_PLUGIN_ENABLED', 'Plugin Enabled'),
+            ('EVT_PLUGIN_DISABLED', 'Plugin Disabled'),
+            ('EVT_PLUGIN_LOADED', 'Plugin Loaded'),
+            ('EVT_PLUGIN_UNLOADED', 'Plugin Unloaded'),
             ('EVT_CLIENT_SAY', 'Say'),
             ('EVT_CLIENT_TEAM_SAY', 'Team Say'),
             ('EVT_CLIENT_SQUAD_SAY', 'Squad Say'),

--- a/b3/exceptions.py
+++ b/b3/exceptions.py
@@ -1,0 +1,69 @@
+#
+# BigBrotherBot(B3) (www.bigbrotherbot.net)
+# Copyright (C) 2005 Michael "ThorN" Thornton
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# CHANGELOG
+#
+# 2015-03-08 - 1.0 - Fenix - initial release
+# 2015-03-09 - 1.1 - Fenix - added ProgrammingError exception class
+
+
+class ConfigFileNotFound(Exception):
+    """
+    Raised whenever the configuration file can't be found.
+    """
+    def __init__(self, message):
+        Exception.__init__(self, message)
+        
+    def __str__(self):
+        return repr(self.message)
+
+
+class ConfigFileNotValid(Exception):
+    """
+    Raised whenever we are parsing an invalid configuration file.
+    """
+    def __init__(self, message):
+        Exception.__init__(self, message)
+        
+    def __str__(self):
+        return repr(self.message)
+
+
+class MissingRequirement(Exception):
+    """
+    Raised whenever we can't initialize a functionality because some modules are missing.
+    """
+    def __init__(self, message, throwable=None):
+        Exception.__init__(self, message)
+        self.throwable = throwable
+
+    def __str__(self):
+        if self.throwable:
+            return '%r - %r' % (repr(self.message), repr(self.throwable))
+        return repr(self.message)
+
+
+class ProgrammingError(Exception):
+    """
+    Raised whenever a programming error is detected.
+    """
+    def __init__(self, message):
+        Exception.__init__(self, message)
+
+    def __str__(self):
+        return repr(self.message)

--- a/b3/plugin.py
+++ b/b3/plugin.py
@@ -41,9 +41,12 @@
 # 28/07/2014 - 1.9   - Fenix     - syntax cleanup
 #                                - added default event mapping hooks for EVT_EXIT and EVT_STOP
 # 08/01/2015 - 1.9.1 - Fenix     - make sure not to load 'None' object as configuration file
+# 08/03/2015 - 1.9.2 - Fenix     - added requiresPlugins attribute in Plugin class
+#                                - added PluginData class
+#                                - produce EVT_PLUGIN_ENABLED ands EVT_PLUGIN_DISABLED
 
 __author__ = 'ThorN, Courgette'
-__version__ = '1.9.1'
+__version__ = '1.9.2'
 
 import b3.config
 import b3.events
@@ -64,6 +67,7 @@ class Plugin:
     eventmap = None
     events = []
     requiresConfigFile = True   # plugin developers : customize this
+    requiresPlugins = []        # plugin developers : customize this
     working = True
 
     def __init__(self, console, config=None):
@@ -96,6 +100,8 @@ class Plugin:
         Enable the plugin.
         """
         self._enabled = True
+        name = b3.functions.right_cut(self.__class__.__name__, 'Plugin').lower()
+        self.console.queueEvent(self.console.getEvent('EVT_PLUGIN_ENABLED', data=name))
         self.onEnable()
 
     def disable(self):
@@ -103,6 +109,8 @@ class Plugin:
         Disable the plugin.
         """
         self._enabled = False
+        name = b3.functions.right_cut(self.__class__.__name__, 'Plugin').lower()
+        self.console.queueEvent(self.console.getEvent('EVT_PLUGIN_DISABLED', data=name))
         self.onDisable()
 
     def isEnabled(self):
@@ -392,3 +400,26 @@ class Plugin:
         """
         self.warning('use of deprecated method: startup()')
         pass
+
+
+class PluginData(object):
+    """
+    Class used to hold plugin data needed for plugin instance initialization.
+    """
+    def __init__(self, name, module=None, clazz=None, conf=None, disabled=False):
+        """
+        Inizialize a new PluginData object instance
+        :param name: The plugin name as string
+        :param module: The reference of the module implementing the plugin
+        :param clazz: The class implementing the plugin
+        :param conf: The configuration file instance of the plugin (if any)
+        :param disabled: Whether this plugin needs to be initialized as disabled
+        """
+        self.name = name.lower()
+        self.module = module
+        self.clazz = clazz
+        self.conf = conf
+        self.disabled = disabled
+
+    def __repr__(self):
+        return 'PluginData<%s>' % self.name

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -226,3 +226,15 @@ class Test_getStuffSoundingLike(unittest.TestCase):
 
     def test_fallback(self):
         self.assertListEqual(['bar', 'william', 'joe', 'averell', 'foO', 'jack'], functions.getStuffSoundingLike('xxx', ['bar', 'foO', 'joe', 'jack', 'averell', 'william']))
+
+
+class Test_topologicalSort(unittest.TestCase):
+
+    def test_topological_sort(self):
+        dep_list = [('myplugin4', {'myplugin2', 'myplugin1'}),
+                    ('myplugin2', {'myplugin1'}),
+                    ('myplugin3', {}),
+                    ('myplugin1', {}),
+                    ('myplugin5', {'myplugin1', 'myplugin3', 'myplugin4'})]
+        sorted_list = [x for x in functions.topological_sort(dep_list)]
+        self.assertListEqual(sorted_list, ['myplugin3', 'myplugin1', 'myplugin2', 'myplugin4', 'myplugin5'])


### PR DESCRIPTION
I made some major changes to plugin loading. The `Plugin` class now declares a new attribute customizable by plugin developers: `requiresPlugins`: it's a list of plugins names a plugin needs in order to work properly.
It's fairly simple to use. So if I have 3 plugins `custom1`, `custom2`, `custom3` and `custom1` needs the other 2 to work, the syntax will be:

```python
class Custom1Plugin(b3.plugin.Plugin):
    requiresPlugins = ['custom2', 'custom3']
```
Everything will be handled then by the B3 core.
The parser now follows those steps:

* First load the plugin list from B3 main configuration file
* Then remove from the list of plugins to be loaded the ones that have missing modules (or configuration file if they require one: the automatic configuration file search still works here)
* Check that all the plugins in the plugin list meets the necessary requirements: here B3 checks for plugin dependency. When a dependency is not met, B3 tries to fix this by trying to load the missing plugin (auto search in plugins directories, both module and configuration file). This process happens recursively using DFS (so load plugin dependencies from the ground up). If also one of those dependencies can't be satisfied, the *root* plugin will be discarded and not loaded.
* Topological sort over the plugin list: make sure that plugin object instances are created according to the plugin depencency order (so in the above case `custom2` and `custom3` are initialized before `custom1`)
* Admin plugin still is sorted as first plugin since every other plugin needs it

The algorithm should be solid. I didn't came up with a test case (only for the topological sort) but I tested it live on a server and seems to work.



