### PR TITLE
[PARSER] minor fixes to plugin dependency loading

### DIFF
--- a/b3/exceptions.py
+++ b/b3/exceptions.py
@@ -54,7 +54,7 @@ class MissingRequirement(Exception):
 
     def __str__(self):
         if self.throwable:
-            return '%r - %r' % (repr(self.message), repr(self.throwable))
+            return '%s - %r' % (self.message, repr(self.throwable))
         return repr(self.message)
 
 


### PR DESCRIPTION
I fixed some minor issue related to the plugin dependency loading. I built 2 plugins `location` and `geolocation` so that the first requires the second one, and then I performed some live tests (since creating python tests for this would be quite a challenge). Here is an extract opf my B3 log file:

```
150316 13:48:53	BOT    	'www.bigbrotherbot.net (b3) v1.10.0 [posix] [PoisonIvy]'
150316 13:48:53	BOT    	'Python: 2.7.3 (default, Mar 13 2014, 11:03:55) \n[GCC 4.7.2]'
150316 13:48:53	BOT    	'Default encoding: ascii'
150316 13:48:53	BOT    	'Starting Iourt42Parser v1.29 for server 127.0.0.1:33337'
150316 13:48:53	BOT    	'--------------------------------------------'
150316 13:48:53	BOT    	'Connecting to MySQL database: mysql://b3:******@localhost:3306/TEST_1...'
150316 13:48:53	BOT    	'Successfully established a connection with MySQL database'
150316 13:48:53	BOT    	'Game log /home/servers/test1/urbanterror/q3ut4/test1.log'
150316 13:48:53	BOT    	'Starting bot reading file: /home/servers/test1/urbanterror/q3ut4/test1.log'
150316 13:48:53	BOT    	'Rcon status cache expire time: [2 sec] Type: [memory]'
150316 13:48:53	VERBOSE	"RCON sending (127.0.0.1:33337) 'status'"
150316 13:48:54	VERBOS2	"RCON: received 'map: ut4_casa\\nnum score ping name            lastmsg address               qport rate\\n--- ----- ---- --------------- ------- --------------------- ----- -----\\n\\n'"
150316 13:48:54	BOT    	'Loading plugins (external plugin directory: /home/servers/test1/bigbrotherbot/b3/extplugins)'
150316 13:48:54	BOT    	'Loading configuration file b3/conf/plugin_admin.ini for plugin admin'
150316 13:48:54	VERBOSE	'Location is not a built-in plugin (No module named location)'
150316 13:48:54	VERBOSE	'Trying external plugin directory : /home/servers/test1/bigbrotherbot/b3/extplugins'
150316 13:48:54	BOT    	'Loading configuration file /home/servers/test1/bigbrotherbot/b3/extplugins/location/conf/plugin_location.ini for plugin location'
150316 13:48:54	WARNING	'Plugin location has unmet dependency : geolocation : trying to load plugin geolocation...'
150316 13:48:54	DEBUG	'Looking for plugin geolocation module and configuration file...'
150316 13:48:54	VERBOSE	'Geolocation is not a built-in plugin (No module named geolocation)'
150316 13:48:54	VERBOSE	'Trying external plugin directory : /home/servers/test1/bigbrotherbot/b3/extplugins'
150316 13:48:55	DEBUG	'No configuration file specified for plugin geolocation: is not required either'
150316 13:48:55	DEBUG	'Plugin location dependency satisfied: geolocation'
150316 13:48:55	BOT    	'Sorting plugins according to their inclusion requirements...'
150316 13:48:55	BOT    	'Ready to create plugin instances: admin, geolocation, location'
150316 13:48:55	BOT    	'Loading plugin #1 admin [b3/conf/plugin_admin.ini]'
150316 13:48:55	DEBUG	'AdminPlugin: register event <Stop Process>'
150316 13:48:55	DEBUG	'AdminPlugin: created event mapping: <Stop Process:onStop>'
150316 13:48:55	DEBUG	'AdminPlugin: register event <Program Exit>'
150316 13:48:55	DEBUG	'AdminPlugin: created event mapping: <Program Exit:onExit>'
150316 13:48:55	BOT    	'Plugin admin (1.34.2 - ThorN, xlr8or, Courgette, Ozon, Fenix) loaded'
150316 13:48:55	BOT    	'Loading plugin #2 geolocation [--]'
150316 13:48:55	DEBUG	'GeolocationPlugin: register event <Stop Process>'
150316 13:48:55	DEBUG	'GeolocationPlugin: created event mapping: <Stop Process:onStop>'
150316 13:48:55	DEBUG	'GeolocationPlugin: register event <Program Exit>'
150316 13:48:55	DEBUG	'GeolocationPlugin: created event mapping: <Program Exit:onExit>'
150316 13:48:55	INFO	'GeolocationPlugin: creating geolocators object instances...'
150316 13:48:55	BOT    	'Plugin geolocation (1.0 - Fenix) loaded'
150316 13:48:55	BOT    	'Loading plugin #3 location [/home/servers/test1/bigbrotherbot/b3/extplugins/location/conf/plugin_location.ini]'
150316 13:48:55	DEBUG	'LocationPlugin: register event <Stop Process>'
150316 13:48:55	DEBUG	'LocationPlugin: created event mapping: <Stop Process:onStop>'
150316 13:48:55	DEBUG	'LocationPlugin: register event <Program Exit>'
150316 13:48:55	DEBUG	'LocationPlugin: created event mapping: <Program Exit:onExit>'
150316 13:48:55	BOT    	'Plugin location (2.0 - Fenix, Courgette) loaded'
```

As you can see, the `geolocation` plugin was missing from `b3.ini` but the plugin folder was there, so B3 tries to load it in order to start the `location` plugin. Plugins are then sorted according to their requirements (and so in this case since plugin `location` requires `geolocation` then `geolocation` is started first in order for events to be processed by this one before passing them to the `location` plugin). Here is the line from the log: `Ready to create plugin instances: admin, geolocation, location'`