### PR TITLE
plugin improvement and b3.sh addon

### DIFF
--- a/b3/extplugins/xlrstats/__init__.py
+++ b/b3/extplugins/xlrstats/__init__.py
@@ -238,13 +238,13 @@ class XlrstatsPlugin(b3.plugin.Plugin):
         PlayerActions._table = self.playeractions_table
 
         # register the events we're interested in.
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_JOIN'), self.onJoin)
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_KILL'), self.onKill)
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_KILL_TEAM'), self.onTeamKill)
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_SUICIDE'), self.onSuicide)
-        self.registerEvent(self.console.getEventID('EVT_GAME_ROUND_START'), self.onRoundStart)
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_ACTION'), self.onAction)       # for game-events/actions
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_DAMAGE'), self.onDamage)       # for assist recognition
+        self.registerEvent('EVT_CLIENT_JOIN', self.onJoin)
+        self.registerEvent('EVT_CLIENT_KILL', self.onKill)
+        self.registerEvent('EVT_CLIENT_KILL_TEAM', self.onTeamKill)
+        self.registerEvent('EVT_CLIENT_SUICIDE', self.onSuicide)
+        self.registerEvent('EVT_GAME_ROUND_START', self.onRoundStart)
+        self.registerEvent('EVT_CLIENT_ACTION', self.onAction)       # for game-events/actions
+        self.registerEvent('EVT_CLIENT_DAMAGE', self.onDamage)       # for assist recognition
 
         # get the Client.id for the bot itself (guid: WORLD or Server(bfbc2/moh/hf))
         sclient = self.console.clients.getByGUID("WORLD")
@@ -2264,8 +2264,8 @@ class CtimePlugin(b3.plugin.Plugin):
         Initialize plugin.
         """
         self.debug('starting subplugin...')
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_AUTH'), self.onAuth)
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_DISCONNECT'), self.onDisconnect)
+        self.registerEvent('EVT_CLIENT_AUTH', self.onAuth)
+        self.registerEvent('EVT_CLIENT_DISCONNECT', self.onDisconnect)
 
     ####################################################################################################################
     #                                                                                                                  #
@@ -2394,10 +2394,10 @@ class BattlestatsPlugin(b3.plugin.Plugin):
         Initialize plugin.
         """
         self.console.debug('starting subplugin...')
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_AUTH'), self.onAuth)
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_DISCONNECT'), self.onDisconnect)
-        self.registerEvent(self.console.getEventID('EVT_GAME_ROUND_START'), self.onRoundStart)
-        self.registerEvent(self.console.getEventID('EVT_GAME_ROUND_END'), self.onRoundEnd)
+        self.registerEvent('EVT_CLIENT_AUTH', self.onAuth)
+        self.registerEvent('EVT_CLIENT_DISCONNECT', self.onDisconnect)
+        self.registerEvent('EVT_GAME_ROUND_START', self.onRoundStart)
+        self.registerEvent('EVT_GAME_ROUND_END', self.onRoundEnd)
 
     ####################################################################################################################
     #                                                                                                                  #

--- a/b3/extplugins/xlrstats/__init__.py
+++ b/b3/extplugins/xlrstats/__init__.py
@@ -50,6 +50,7 @@
 #                                               mess with GUIDs since that's already done in parsers (where it should be)
 # 23-11-2014 - 3.0.0-beta.11 - Fenix          - added requiresConfigFile = False attribute to Ctime and XlrstatsHistory subplugins
 # 08-02-2014 - 3.0.0-beta.12 - Fenix          - fixed SQL queries quote escaping
+# 17-03-2015 - 3.0.0-beta.13 - Fenix          - replaced deprecated startup() with onStartup()
 
 
 
@@ -60,7 +61,7 @@
 # XLRstats Real Time playerstats plugin
 
 __author__ = 'xlr8or & ttlogic'
-__version__ = '3.0.0-beta.12'
+__version__ = '3.0.0-beta.13'
 
 # Version = major.minor.patches(-development.version)
 
@@ -198,7 +199,7 @@ class XlrstatsPlugin(b3.plugin.Plugin):
         self.query = None                 # shortcut to the storage.query function
         b3.plugin.Plugin.__init__(self, console, config)
 
-    def startup(self):
+    def onStartup(self):
         """
         Initialize plugin.
         """
@@ -279,7 +280,7 @@ class XlrstatsPlugin(b3.plugin.Plugin):
                 #start the xlrstats history plugin
                 p = XlrstatshistoryPlugin(self.console, self.history_weekly_table,
                                           self.history_monthly_table, self.playerstats_table)
-                p.startup()
+                p.onStartup()
             else:
                 self.keep_history = False
                 self._xlrstatstables = [self.playerstats_table, self.weaponstats_table, self.weaponusage_table,
@@ -317,11 +318,11 @@ class XlrstatsPlugin(b3.plugin.Plugin):
         # start the ctime subplugin
         if self.keep_time:
             p = CtimePlugin(self.console, self.ctime_table)
-            p.startup()
+            p.onStartup()
 
         #start the xlrstats controller
         #p = XlrstatscontrollerPlugin(self.console, self.min_players, self.silent)
-        #p.startup()
+        #p.onStartup()
 
         # get the map we're in, in case this is a new map and we need to create a db record for it.
         mapstats = self.get_MapStats(self.console.game.mapName)
@@ -2016,7 +2017,7 @@ class XlrstatsPlugin(b3.plugin.Plugin):
 #         self.registerEvent(b3.events.EVT_STOP)
 #         self.registerEvent(b3.events.EVT_EXIT)
 #
-#     def startup(self):
+#     def onStartup(self):
 #         self.console.debug('Starting SubPlugin: XlrstatsControllerPlugin')
 #         #get a reference to the main Xlrstats plugin
 #         self._xlrstatsPlugin = self.console.getPlugin('xlrstats')
@@ -2107,7 +2108,7 @@ class XlrstatshistoryPlugin(b3.plugin.Plugin):
         self._cronTab = b3.cron.PluginCronTab(self, self.purge, 0, self._minutes, hoursGMT, '*', '*', '*')
         self.console.cron + self._cronTab
 
-    def startup(self):
+    def onStartup(self):
         """
         Initialize plugin.
         """
@@ -2259,7 +2260,7 @@ class CtimePlugin(b3.plugin.Plugin):
         self._cronTab = b3.cron.PluginCronTab(self, self.purge, 0, self._minutes, hoursGMT, '*', '*', '*')
         self.console.cron + self._cronTab
 
-    def startup(self):
+    def onStartup(self):
         """
         Initialize plugin.
         """
@@ -2389,7 +2390,7 @@ class BattlestatsPlugin(b3.plugin.Plugin):
         self.gameLog = None
         self.clientsLog = None
 
-    def startup(self):
+    def onStartup(self):
         """
         Initialize plugin.
         """

--- a/b3/parsers/iourt42.py
+++ b/b3/parsers/iourt42.py
@@ -1323,7 +1323,7 @@ class Iourt42Parser(Iourt41Parser):
             this.onChat(new_event)
 
         self.spamcontrolPlugin.onRadio = new.instancemethod(onRadio, self.spamcontrolPlugin, SpamcontrolPlugin)
-        self.spamcontrolPlugin.registerEvent(self.getEventID('EVT_CLIENT_RADIO'), self.spamcontrolPlugin.onRadio)
+        self.spamcontrolPlugin.registerEvent('EVT_CLIENT_RADIO', self.spamcontrolPlugin.onRadio)
 
     @staticmethod
     def patch_Clients():

--- a/b3/plugin.py
+++ b/b3/plugin.py
@@ -44,9 +44,11 @@
 # 08/03/2015 - 1.9.2 - Fenix     - added requiresPlugins attribute in Plugin class
 #                                - added PluginData class
 #                                - produce EVT_PLUGIN_ENABLED ands EVT_PLUGIN_DISABLED
+# 17/02/2015 - 1.9.3 - Fenix     - allow plugins to register events using both event key and event id: this allows
+#                                  plugin developers to write less code
 
 __author__ = 'ThorN, Courgette'
-__version__ = '1.9.2'
+__version__ = '1.9.3'
 
 import b3.config
 import b3.events
@@ -92,8 +94,8 @@ class Plugin:
                     self.critical("Use a XML editor to modify your config files: it makes easy to spot errors")
                     raise
 
-        self.registerEvent(self.console.getEventID('EVT_STOP'), self.onStop)
-        self.registerEvent(self.console.getEventID('EVT_EXIT'), self.onExit)
+        self.registerEvent('EVT_STOP', self.onStop)
+        self.registerEvent('EVT_EXIT', self.onExit)
 
     def enable(self):
         """
@@ -223,6 +225,9 @@ class Plugin:
         :param name: The event name
         :param args: An optional list of event handlers
         """
+        # if we are given the event key, get the event id instead: this will return
+        # the event id even if we supplied it as input parameter
+        name = self.console.getEventID(name)
         self.events.append(name)
         self.console.registerHandler(name, self)
         if len(args) > 0:

--- a/b3/plugins/admin/__init__.py
+++ b/b3/plugins/admin/__init__.py
@@ -492,10 +492,10 @@ class AdminPlugin(b3.plugin.Plugin):
         """
         Plugin startup.
         """
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_SAY'), self.OnSay)
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_TEAM_SAY'), self.OnSay)
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_SQUAD_SAY'), self.OnSay)
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_PRIVATE_SAY'), self.OnPrivateSay)
+        self.registerEvent('EVT_CLIENT_SAY', self.OnSay)
+        self.registerEvent('EVT_CLIENT_TEAM_SAY', self.OnSay)
+        self.registerEvent('EVT_CLIENT_SQUAD_SAY', self.OnSay)
+        self.registerEvent('EVT_CLIENT_PRIVATE_SAY', self.OnPrivateSay)
         self.createEvent('EVT_ADMIN_COMMAND', 'Admin Command')
 
         try:

--- a/b3/plugins/censor/__init__.py
+++ b/b3/plugins/censor/__init__.py
@@ -109,10 +109,10 @@ class CensorPlugin(b3.plugin.Plugin):
             self.critical('could not start without admin plugin')
             return False
 
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_SAY'))
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_TEAM_SAY'))
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_NAME_CHANGE'))
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_AUTH'))
+        self.registerEvent('EVT_CLIENT_SAY')
+        self.registerEvent('EVT_CLIENT_TEAM_SAY')
+        self.registerEvent('EVT_CLIENT_NAME_CHANGE')
+        self.registerEvent('EVT_CLIENT_AUTH')
 
     def onLoadConfig(self):
         """

--- a/b3/plugins/cmdmanager/__init__.py
+++ b/b3/plugins/cmdmanager/__init__.py
@@ -108,7 +108,7 @@ class CmdmanagerPlugin(b3.plugin.Plugin):
                     self._adminPlugin.registerCommand(self, cmd, level, func, alias)
 
         # register events needed
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_AUTH'), self.onAuth)
+        self.registerEvent('EVT_CLIENT_AUTH', self.onAuth)
 
         # notice plugin started
         self.debug('plugin started')

--- a/b3/plugins/login/__init__.py
+++ b/b3/plugins/login/__init__.py
@@ -85,7 +85,7 @@ class LoginPlugin(b3.plugin.Plugin):
             return False
 
         # register the events needed
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_AUTH'), self.onAuth)
+        self.registerEvent('EVT_CLIENT_AUTH', self.onAuth)
 
         # register our commands
         self._adminPlugin.registerCommand(self, 'login', 2, self.cmd_login, secretLevel=1)

--- a/b3/plugins/pingwatch/__init__.py
+++ b/b3/plugins/pingwatch/__init__.py
@@ -100,7 +100,7 @@ class PingwatchPlugin(b3.plugin.Plugin):
             return False
 
         # register events needed
-        self.registerEvent(self.console.getEventID('EVT_GAME_EXIT'), self.onGameExit)
+        self.registerEvent('EVT_GAME_EXIT', self.onGameExit)
         self._ignoreTill = self.console.time() + 120  # dont check pings on startup
 
         # register our commands

--- a/b3/plugins/spamcontrol/__init__.py
+++ b/b3/plugins/spamcontrol/__init__.py
@@ -95,9 +95,9 @@ class SpamcontrolPlugin(b3.plugin.Plugin):
         Initialize the plugin.
         """
         # register the events needed
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_SAY'), self.onChat)
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_TEAM_SAY'), self.onChat)
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_PRIVATE_SAY'), self.onChat)
+        self.registerEvent('EVT_CLIENT_SAY', self.onChat)
+        self.registerEvent('EVT_CLIENT_TEAM_SAY', self.onChat)
+        self.registerEvent('EVT_CLIENT_PRIVATE_SAY', self.onChat)
 
         self._adminPlugin = self.console.getPlugin('admin')
         if self._adminPlugin:

--- a/b3/plugins/stats/__init__.py
+++ b/b3/plugins/stats/__init__.py
@@ -210,13 +210,13 @@ class StatsPlugin(b3.plugin.Plugin):
                 if func:
                     self._adminPlugin.registerCommand(self, cmd, level, func, alias)
 
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_DAMAGE_TEAM'), self.onDamageTeam)
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_KILL_TEAM'), self.onTeamKill)
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_KILL'), self.onKill)
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_DAMAGE'), self.onDamage)
-        self.registerEvent(self.console.getEventID('EVT_GAME_EXIT'), self.onShowAwards)
-        self.registerEvent(self.console.getEventID('EVT_GAME_MAP_CHANGE'), self.onShowAwards)
-        self.registerEvent(self.console.getEventID('EVT_GAME_ROUND_START'), self.onRoundStart)
+        self.registerEvent('EVT_CLIENT_DAMAGE_TEAM', self.onDamageTeam)
+        self.registerEvent('EVT_CLIENT_KILL_TEAM', self.onTeamKill)
+        self.registerEvent('EVT_CLIENT_KILL', self.onKill)
+        self.registerEvent('EVT_CLIENT_DAMAGE', self.onDamage)
+        self.registerEvent('EVT_GAME_EXIT', self.onShowAwards)
+        self.registerEvent('EVT_GAME_MAP_CHANGE', self.onShowAwards)
+        self.registerEvent('EVT_GAME_ROUND_START', self.onRoundStart)
 
     ####################################################################################################################
     #                                                                                                                  #

--- a/b3/plugins/tk/__init__.py
+++ b/b3/plugins/tk/__init__.py
@@ -411,12 +411,12 @@ class TkPlugin(b3.plugin.Plugin):
         """
         Plugin startup
         """
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_DAMAGE_TEAM'))
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_KILL_TEAM'))
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_DISCONNECT'))
-        self.registerEvent(self.console.getEventID('EVT_GAME_EXIT'))
-        self.registerEvent(self.console.getEventID('EVT_GAME_ROUND_END'))
-        self.registerEvent(self.console.getEventID('EVT_GAME_ROUND_START'))
+        self.registerEvent('EVT_CLIENT_DAMAGE_TEAM')
+        self.registerEvent('EVT_CLIENT_KILL_TEAM')
+        self.registerEvent('EVT_CLIENT_DISCONNECT')
+        self.registerEvent('EVT_GAME_EXIT')
+        self.registerEvent('EVT_GAME_ROUND_END')
+        self.registerEvent('EVT_GAME_ROUND_START')
 
         self._adminPlugin = self.console.getPlugin('admin')
         if self._adminPlugin:

--- a/b3/plugins/updater/__init__.py
+++ b/b3/plugins/updater/__init__.py
@@ -104,15 +104,15 @@ class UpdaterPlugin(b3.plugin.Plugin):
 
         # create an events for a proper B3 shutdown: the updating thread fails to shutdown B3 properly when
         # invoking self.console.die() from whithin the thread itself so we need to to handle this from outside
-        self.console.Events.createEvent('EVT_SHUTDOWN_REQUEST', 'Shutdown request')
+        self.console.createEvent('EVT_SHUTDOWN_REQUEST', 'Shutdown request')
 
         # register commands
         self._adminPlugin.registerCommand(self, 'update', 100, self.cmd_update)
         self._adminPlugin.registerCommand(self, 'checkupdate', 100, self.cmd_checkupdate)
 
         # register events needed
-        self.registerEvent(self.console.getEventID('EVT_SHUTDOWN_REQUEST'), self.onShutdownRequest)
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_AUTH'), self.onAuth)
+        self.registerEvent('EVT_SHUTDOWN_REQUEST', self.onShutdownRequest)
+        self.registerEvent('EVT_CLIENT_AUTH', self.onAuth)
 
         # notice plugin started
         self.debug('plugin started')

--- a/b3/plugins/welcome/__init__.py
+++ b/b3/plugins/welcome/__init__.py
@@ -110,7 +110,7 @@ class WelcomePlugin(b3.plugin.Plugin):
                     self._adminPlugin.registerCommand(self, cmd, level, func, alias)
 
         # register events needed
-        self.registerEvent(self.console.getEventID('EVT_CLIENT_AUTH'), self.onAuth)
+        self.registerEvent('EVT_CLIENT_AUTH', self.onAuth)
 
     def onLoadConfig(self):
         """

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -31,8 +31,7 @@ the [man page](http://linux.die.net/man/8/useradd)
 As described above, the script will allow you to launch multiple B3 instances so you can manage multiple game servers.
 In order to do that you need to specify multiple B3 configuration files to be used to start B3 instances: those 
 configuration files needs to be placed in the B3 main configuration directory (namely **b3/conf**). The names of such
-configuration files needs to follow a specific pattern: `b3_[<name>].[.ini|.xml]` (*.ini* format will be introduced soon 
-as B3 main configuration file, but this script is already .ini capable).  
+configuration files needs to follow a specific pattern: `b3_[<name>].[.ini|.xml]`.  
 
 As an example let's assume you are running 2 game servers and you need to start **2** B3 intances: let's call them 
 **tdm** and **ctf**. What you need to do is pretty simple: you need to create **2** configuration files and place them 

--- a/scripts/b3.sh
+++ b/scripts/b3.sh
@@ -2,8 +2,8 @@
 
 # Big Brother Bot (B3) Management - http://www.bigbrotherbot.net
 # Maintainer: Daniele Pantaleone <fenix@bigbrotherbot.net>
-# App Version: 0.9
-# Last Edit: 08/02/2015
+# App Version: 0.11
+# Last Edit: 17/03/2015
 
 ### BEGIN INIT INFO
 # Provides:          b3
@@ -40,12 +40,14 @@
 #                                    - temporarily activate logging using B3_LOG_ENABLED environment variable
 #                                    - fix log failure detection and in case of errors, display the reason why it failed
 #  2015-03-06 - 0.10 - Fenix         - removed python 2.6 support
+#  2015-03-17 - 0.11 - Fenix         - added developer mode, temporarily activable with B3_DEV environment variable
 
 
 ### SETUP
 AUTO_RESTART="1"                   # will run b3 in auto-restart mode if set to 1
 DATE_FORMAT="%a, %b %d %Y - %r"    # data format to be used when logging console output
 LOG_ENABLED="${B3_LOG_ENABLED:-0}" # if set to 1, will log console output to file
+DEVELOPER="${B3_DEV:-0}"           # if set to 1, will activate developer mode
 USE_COLORS="1"                     # if set to 1, will make use of bash color codes in the console output
 
 ### DO NOT MODIFY!!!
@@ -418,9 +420,11 @@ B3_DIR="$(dirname ${SCRIPT_DIR})"
 
 # check that the script is not executed by super user to avoid permission problems
 # we will allow the B3 status check tho since the operation is totally harmless
-if ([ ${UID} -eq 0 ] && [ -n "${1}" ] && [ "${1}" != "status" ]); then
-  p_out "^1ERROR^0: do not execute B3 as super user [root]"
-  exit 1
+if [ ! "${DEVELOPER}" -eq 0 ]; then # allow developers to use root to start b3
+    if ([ ${UID} -eq 0 ] && [ -n "${1}" ] && [ "${1}" != "status" ]); then
+      p_out "^1ERROR^0: do not execute B3 as super user [root]"
+      exit 1
+    fi
 fi
 
 # check for python to be installed in the system

--- a/tests/plugins/test_pluginmanager.py
+++ b/tests/plugins/test_pluginmanager.py
@@ -407,7 +407,7 @@ class Test_commands(Pluginmanager_TestCase):
         self.adminPlugin._commands['mockcommand'] = Command(plugin=mock_plugin, cmd='mockcommand', level=100, func=mock_func)
         ###### MOCK EVENT
         mock_plugin.onSay = Mock()
-        mock_plugin.registerEvent(self.console.getEventID('EVT_CLIENT_SAY'), mock_plugin.onSay)
+        mock_plugin.registerEvent('EVT_CLIENT_SAY', mock_plugin.onSay)
         ###### MOCK CRON
         mock_plugin.mockCronjob = Mock()
         mock_plugin.mockCrontab = b3.cron.PluginCronTab(mock_plugin, mock_plugin.mockCronjob, minute='*', second= '*/60')

--- a/tests/plugins/test_spamcontrol.py
+++ b/tests/plugins/test_spamcontrol.py
@@ -273,7 +273,7 @@ class Test_game_specific_spam(SpamcontrolTestCase):
             this.onChat(new_event)
 
         self.p.onRadio = new.instancemethod(onRadio, self.p, SpamcontrolPlugin)
-        self.p.registerEvent(self.p.console.getEventID('EVT_CLIENT_RADIO'), self.p.onRadio)
+        self.p.registerEvent('EVT_CLIENT_RADIO', self.p.onRadio)
 
         # patch joe to make him able to send radio messages
         def radios(me, text):


### PR DESCRIPTION
I added the possibility to use directly the event key when registering events inside a plugin (so you do not have to retrieved the event ID using the key, and so you write less code).
I also added a new variable to the b3.sh script, `B3_DEV`: when set to 1 allows the usage of root user to start B3 (to speed up modifications and addons tests)