### PR TITLE
Update iourt43.py

### DIFF
--- a/b3/parsers/iourt43.py
+++ b/b3/parsers/iourt43.py
@@ -1076,7 +1076,7 @@ class Iourt43Parser(Iourt41Parser):
             self.debug('No attacker')
             return None
 
-        return self.getEvent(self.EVT_ASSIST, client=client, target=victim, data=attacker)
+        return self.getEvent('EVT_ASSIST', client=client, target=victim, data=attacker)
 
     ####################################################################################################################
     #                                                                                                                  #


### PR DESCRIPTION
Solve UrT4.3 parser assist event bug:

ERROR    'Could not parse line \'Iourt43Parser\' object has no attribute \'EVT_ASSIST\': [(\'/home/test/b3bot/b3/parser.py\', 1324, \'run\', \'self.parseLine(line)\'), (\'/home/test/b3bot/b3/parsers/q3a/abstractParser.py\', 257, \'parseLine\', \'event = func(action, data, match)\'), (\'/home/test/b3bot/b3/parsers/iourt43.py\', 1079, \'OnAssist\', "return self.getEvent(\'EVT_ASSIST\', client=client, target=victim, data=attacker)")]'