### PR TITLE
Fix for NoneTypes Error

### DIFF
--- a/b3/__init__.py
+++ b/b3/__init__.py
@@ -159,7 +159,7 @@ def getConfPath(decode=False, conf=None):
         else:
             raise TypeError('invalid configuration type specified: expected str|XmlConfigParser|CfgConfigParser|MainConfig, got %s instead' % type(conf))
     else:
-        path = confdir or os.path.dirname(console.config.fileName)
+        path = confdir
 
     if not decode:
         return path


### PR DESCRIPTION
I have fixed the NoneType Error due to using a non existant aka null value which was: os.path.dirname(console.conf.fileName)