### PR TITLE
Plugin 'poweradminurt': Update README to state support for UrT 4.3

### DIFF
--- a/b3/plugins/poweradminurt/README.rst
+++ b/b3/plugins/poweradminurt/README.rst
@@ -7,7 +7,7 @@ http://www.bigbrotherbot.net
 Description
 
 -----------
-This plugin brings Urban Terror 4.1 and 4.2 specific features to Bigbrotherbot.
+This plugin brings Urban Terror 4.1 / 4.2 / 4.3 specific features to Bigbrotherbot.
 
 
 Commands


### PR DESCRIPTION
I was looking for a version of the plugin that worked with UrT 4.3 (didn't realize it was included in b3), found it here in the repo, but was thrown off because the README still said 4.2
I have no idea what happened to the last line, i didn't change it, and the commit doesn't seem to change it, but it still shows up as a change..