### PR TITLE
Plugin XLRStats: disable command 'xlrinit' in plugin .ini

### DIFF
--- a/b3/conf/plugin_xlrstats.ini
+++ b/b3/conf/plugin_xlrstats.ini
@@ -82,7 +82,9 @@ xlrtopstats: reg
 xlrhide: fulladmin
 xlrid: guest
 xlrstatus: user
-xlrinit: superadmin
+
+# disabled: does not only reset stats, but also removes all registered b3 users
+#xlrinit: superadmin
 
 [messages]
 # cmd_xlrstats: Configure the message when someone use !xlrstats


### PR DESCRIPTION
According to the help text, this command is supposed to reset all stats, but also wipes B3's client table.
We just noticed this because someone accidentally called this on a fresh server, no data was lost.